### PR TITLE
install gnome desktop packages and enable gui bootmode in Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Vagrantfile for setting up an Ubuntu 13.04 development box with
  * chef
  * vagrant
  * lxc
+ * gnome desktop
 
 Requirements
 ------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,8 @@ Vagrant::configure("2") do |config|
         "--memory", 2048,
         "--cpus", 2
       ]
+      # yes we have a gui
+      vbox.gui = true
     end
     
     # provisioning

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,6 @@
 
 include_recipe "dev-box::base"
+include_recipe "dev-box::gui"
 include_recipe "dev-box::user"
 include_recipe "dev-box::ruby"
 include_recipe "dev-box::vagrant"

--- a/recipes/gui.rb
+++ b/recipes/gui.rb
@@ -1,0 +1,4 @@
+
+# install gnome desktop
+package "ubuntu-desktop"
+package "ubuntu-wallpapers"


### PR DESCRIPTION
Adds a GUI to the ubuntu server basebox by installinig the "ubuntu-desktop" and "ubuntu-wallpapers" meta packages. Also sets `virtualbox.gui = true` in the Vagrantfile
