### PR TITLE
Write HTML report of test results for CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,4 @@ test:
   override:
     - vagrant up
     - vagrant ssh -c 'cat ~/vm-setup/cookbooks/vm/test/junit-report.xml' > $CIRCLE_TEST_REPORTS/junit-report.xml
+    - vagrant ssh -c 'cat ~/vm-setup/cookbooks/vm/test/test-report.html' > $CIRCLE_ARTIFACTS/test-report.html

--- a/circle.yml
+++ b/circle.yml
@@ -17,4 +17,4 @@ test:
   override:
     - vagrant up
     - vagrant ssh -c 'cat ~/vm-setup/cookbooks/vm/test/junit-report.xml' > $CIRCLE_TEST_REPORTS/junit-report.xml
-    - vagrant ssh -c 'cat ~/vm-setup/cookbooks/vm/test/test-report.html' > $CIRCLE_ARTIFACTS/test-report.html
+    - vagrant ssh -c 'cat ~/vm-setup/cookbooks/vm/test/test-report.html' > $CIRCLE_TEST_REPORTS/test-report.html

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -8,7 +8,7 @@ unless docker?
   # install atom
   package 'atom' do
     action :install
-    version '1.2.2-1~webupd8~0'
+    version '1.3.0-1~webupd8~0'
   end
 
   # install plugins

--- a/cookbooks/vm/recipes/default.rb
+++ b/cookbooks/vm/recipes/default.rb
@@ -2,6 +2,7 @@
 include_recipe 'vm::base'
 include_recipe 'vm::user'
 include_recipe 'vm::bash'
+include_recipe 'vm::git'
 include_recipe 'vm::chefdk'
 include_recipe 'vm::vagrant'
 include_recipe 'vm::atom'

--- a/cookbooks/vm/recipes/default.rb
+++ b/cookbooks/vm/recipes/default.rb
@@ -2,7 +2,6 @@
 include_recipe 'vm::base'
 include_recipe 'vm::user'
 include_recipe 'vm::bash'
-include_recipe 'vm::git'
 include_recipe 'vm::chefdk'
 include_recipe 'vm::vagrant'
 include_recipe 'vm::atom'

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -10,8 +10,8 @@ unless Chef::Sugar::Docker.docker?(@node)
     let(:atom_config) { file('/home/vagrant/.atom/config.cson') }
     let(:installed_plugins) { devbox_user_command('apm list -i').stdout }
 
-    it 'installs atom 1.2.2' do
-      expect(atom_version).to eq '1.2.2'
+    it 'installs atom 1.3.0' do
+      expect(atom_version).to eq '1.3.0'
     end
 
     it 'installs some useful atom plugins' do

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -103,7 +103,7 @@ verify_vm() {
 
   # run integration tests
   step "run integration tests"
-  rspec --require rspec_junit_formatter --format doc --color --format RspecJunitFormatter --out test/junit-report.xml
+  rspec --require rspec_junit_formatter --format doc --color --format RspecJunitFormatter --out test/junit-report.xml --format html --out test/test-report.html
 }
 
 #


### PR DESCRIPTION
CircleCI's test reporting is currently limited to showing only the number of passed tests, but no detials like test suite / method names etc.. It only shows the names if a test fails, but not in the success case. 

See the discussion here:
https://discuss.circleci.com/t/better-test-reporting/883/

This PR makes rspec additionally create an html report, which is then archived as a build artifact on CircleCI.