### PR TITLE
Use Xvfb in docker / CircleCI

### DIFF
--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -6,12 +6,15 @@ if docker?
   # we need xvfb + libasound2 for starting atom in docker
   package 'xvfb'
   package 'libasound2'
+  # avoid /dev/fuse issues on circleci
+  extra_options = '--no-install-recommends'
 end
 
 # install atom
 package 'atom' do
   action :install
   version '1.3.0-1~webupd8~0'
+  options extra_options || ''
 end
 
 # install plugins

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -2,39 +2,41 @@
 # sets up ppa launchpad repo
 include_recipe 'atom'
 
-# ...skip this in docker containers due to permission issue with /dev/fuse
-unless docker?
+if docker?
+  # we need xvfb + libasound2 for starting atom in docker
+  package 'xvfb'
+  package 'libasound2'
+end
 
-  # install atom
-  package 'atom' do
-    action :install
-    version '1.3.0-1~webupd8~0'
-  end
+# install atom
+package 'atom' do
+  action :install
+  version '1.3.0-1~webupd8~0'
+end
 
-  # install plugins
-  plugins = %w(
-    atom-beautify
-    minimap
-    line-ending-converter
-    language-chef
-    language-batchfile
-  )
-  plugins.each do |plugin|
-    # atom_apm does not work, so we use a bash resource, see
-    # https://github.com/mohitsethi/chef-atom/issues/2
-    bash "install-#{plugin}-atom-plugin" do
-      environment devbox_user_env
-      user devbox_user
-      group devbox_group
-      code "apm install #{plugin}"
-    end
+# install plugins
+plugins = %w(
+  atom-beautify
+  minimap
+  line-ending-converter
+  language-chef
+  language-batchfile
+)
+plugins.each do |plugin|
+  # atom_apm does not work, so we use a bash resource, see
+  # https://github.com/mohitsethi/chef-atom/issues/2
+  bash "install-#{plugin}-atom-plugin" do
+    environment devbox_user_env
+    user devbox_user
+    group devbox_group
+    code "apm install #{plugin}"
   end
+end
 
-  # config tweaks
-  template "#{devbox_userhome}/.atom/config.cson" do
-    source 'atom_config.erb'
-    owner devbox_user
-    group devbox_user
-    mode '0664'
-  end
+# config tweaks
+template "#{devbox_userhome}/.atom/config.cson" do
+  source 'atom_config.erb'
+  owner devbox_user
+  group devbox_user
+  mode '0664'
 end

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -1,36 +1,38 @@
 require 'spec_helper'
 require 'chef/sugar/docker'
 
-# installing atom on docker does not work, so we don't need to test either
-unless Chef::Sugar::Docker.docker?(@node)
+describe 'vm::atom' do
 
-  describe 'vm::atom' do
+  # simulate an X environment in docker / circleci
+  if Chef::Sugar::Docker.docker?(@node)
+    atom_version_cmd = 'xvfb-run atom -v'
+  else
+    atom_version_cmd = 'DISPLAY=:0 atom -v'
+  end
+  let(:atom_version) { devbox_user_command(atom_version_cmd).stdout.strip }
+  let(:atom_config) { file('/home/vagrant/.atom/config.cson') }
+  let(:installed_plugins) { devbox_user_command('apm list -i').stdout }
 
-    let(:atom_version) { devbox_user_command('DISPLAY=:0 atom -v').stdout.strip }
-    let(:atom_config) { file('/home/vagrant/.atom/config.cson') }
-    let(:installed_plugins) { devbox_user_command('apm list -i').stdout }
+  it 'installs atom 1.3.0' do
+    expect(atom_version).to eq '1.3.0'
+  end
 
-    it 'installs atom 1.3.0' do
-      expect(atom_version).to eq '1.3.0'
-    end
+  it 'installs some useful atom plugins' do
+    expect(installed_plugins).to contain 'atom-beautify'
+    expect(installed_plugins).to contain 'minimap'
+    expect(installed_plugins).to contain 'line-ending-converter'
+    expect(installed_plugins).to contain 'language-chef'
+    expect(installed_plugins).to contain 'language-batchfile'
+  end
 
-    it 'installs some useful atom plugins' do
-      expect(installed_plugins).to contain 'atom-beautify'
-      expect(installed_plugins).to contain 'minimap'
-      expect(installed_plugins).to contain 'line-ending-converter'
-      expect(installed_plugins).to contain 'language-chef'
-      expect(installed_plugins).to contain 'language-batchfile'
-    end
-
-    it 'configures atom to have sublime tabs behaviour' do
-      expect(atom_config).to contain 'usePreviewTabs: true'
-    end
-    it 'configures atom to show invisible characters' do
-      expect(atom_config).to contain 'showInvisibles: true'
-    end
-    it 'configures atom to use the "atom-dark" theme' do
-      expect(atom_config).to contain '"atom-dark-ui"'
-      expect(atom_config).to contain '"atom-dark-syntax"'
-    end
+  it 'configures atom to have sublime tabs behaviour' do
+    expect(atom_config).to contain 'usePreviewTabs: true'
+  end
+  it 'configures atom to show invisible characters' do
+    expect(atom_config).to contain 'showInvisibles: true'
+  end
+  it 'configures atom to use the "atom-dark" theme' do
+    expect(atom_config).to contain '"atom-dark-ui"'
+    expect(atom_config).to contain '"atom-dark-syntax"'
   end
 end


### PR DESCRIPTION
This is what atom requires so we can fire it up in docker / circleci and run the atom related tests there as well.

Note that the `/dev/fuse` issues on circleci can often be avoided by `apt-get install <pkg> --no-install-recommends`