### PR TITLE
Add initial Git configuration

### DIFF
--- a/cookbooks/vm/recipes/default.rb
+++ b/cookbooks/vm/recipes/default.rb
@@ -2,6 +2,7 @@
 include_recipe 'vm::base'
 include_recipe 'vm::user'
 include_recipe 'vm::bash'
+include_recipe 'vm::git'
 include_recipe 'vm::chefdk'
 include_recipe 'vm::vagrant'
 include_recipe 'vm::atom'

--- a/cookbooks/vm/recipes/git.rb
+++ b/cookbooks/vm/recipes/git.rb
@@ -5,6 +5,7 @@ end
 
 package 'meld' do
   action :install
+  options '--no-install-recommends'
 end
 
 template "#{devbox_userhome}/.gitconfig" do

--- a/cookbooks/vm/recipes/git.rb
+++ b/cookbooks/vm/recipes/git.rb
@@ -1,0 +1,15 @@
+
+package 'git' do
+  action :install
+end
+
+package 'meld' do
+  action :install
+end
+
+template "#{devbox_userhome}/.gitconfig" do
+  source 'git_config.erb'
+  owner devbox_user
+  group devbox_group
+  mode '0644'
+end

--- a/cookbooks/vm/recipes/git.rb
+++ b/cookbooks/vm/recipes/git.rb
@@ -1,11 +1,18 @@
 
-package 'git' do
-  action :install
+if docker?
+  # we need xvfb for starting meld in docker
+  package 'xvfb'
+  # avoid /dev/fuse issues on circleci
+  extra_options = '--no-install-recommends'
 end
 
 package 'meld' do
   action :install
-  options '--no-install-recommends'
+  options extra_options || ''
+end
+
+package 'git' do
+  action :install
 end
 
 template "#{devbox_userhome}/.gitconfig" do

--- a/cookbooks/vm/spec/integration/recipes/git_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/git_spec.rb
@@ -5,27 +5,30 @@ describe 'vm::git' do
 
   # simulate an X environment in docker / circleci
   if Chef::Sugar::Docker.docker?(@node)
-    meld_version = 'xvfb-run meld --version'
+    meld_version_cmd = 'xvfb-run meld --version'
   else
-    meld_version = 'meld --version'
+    meld_version_cmd = 'meld --version'
   end
+  let(:git_version) { devbox_user_command('git --version') }
+  let(:meld_version) { devbox_user_command(meld_version_cmd) }
+  let(:git_config) { devbox_user_command('git config --global --list').stdout }
 
   it 'installs git' do
     expect(package('git')).to be_installed
-    expect(devbox_user_command('git --version').exit_status).to eq 0
+    expect(git_version.exit_status).to eq 0
   end
 
   it 'installs meld for diffing / merging' do
     expect(package('meld')).to be_installed
-    expect(devbox_user_command(meld_version).exit_status).to eq 0
+    expect(meld_version.exit_status).to eq 0
   end
 
   context '~/.gitconfig' do
     it 'configures meld as the difftool' do
-      pending('todo')
+      expect(git_config).to contain 'diff.tool=meld'
     end
     it 'configures meld as the mergetool' do
-      pending('todo')
+      expect(git_config).to contain 'merge.tool=meld'
     end
   end
 end

--- a/cookbooks/vm/spec/integration/recipes/git_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/git_spec.rb
@@ -1,23 +1,31 @@
 require 'spec_helper'
+require 'chef/sugar/docker'
 
 describe 'vm::git' do
 
-  it 'installs git' do
-    expect(package('git')).to be_installed
-    expect(command('git --version').exit_status).to eq 0
+  # simulate an X environment in docker / circleci
+  if Chef::Sugar::Docker.docker?(@node)
+    meld_version = 'xvfb-run meld --version'
+  else
+    meld_version = 'meld --version'
   end
 
-  it 'installs meld as the diff / merge tool' do
+  it 'installs git' do
+    expect(package('git')).to be_installed
+    expect(devbox_user_command('git --version').exit_status).to eq 0
+  end
+
+  it 'installs meld for diffing / merging' do
     expect(package('meld')).to be_installed
-    expect(command('meld --version').exit_status).to eq 0
+    expect(devbox_user_command(meld_version).exit_status).to eq 0
   end
 
   context '~/.gitconfig' do
     it 'configures meld as the difftool' do
-      expect(command('meld --version').exit_status).to eq 0
+      pending('todo')
     end
     it 'configures meld as the mergetool' do
-      expect(command('meld --version').exit_status).to eq 0
+      pending('todo')
     end
   end
 end

--- a/cookbooks/vm/spec/integration/recipes/git_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/git_spec.rb
@@ -18,7 +18,7 @@ describe 'vm::git' do
     expect(git_version.exit_status).to eq 0
   end
 
-  it 'installs meld for diffing / merging' do
+  it 'installs meld (for diffing and merging)' do
     expect(package('meld')).to be_installed
     expect(meld_version.exit_status).to eq 0
   end
@@ -29,6 +29,24 @@ describe 'vm::git' do
     end
     it 'configures meld as the mergetool' do
       expect(git_config).to contain 'merge.tool=meld'
+    end
+    it 'disables ssl verification' do
+      expect(git_config).to contain 'http.sslverify=false'
+    end
+    context 'aliases' do
+      aliases = {
+        co: 'checkout',
+        ci: 'commit',
+        br: 'branch',
+        st: 'status',
+        unstage: 'reset HEAD --',
+        slog: 'log --pretty=oneline --abbrev-commit'
+      }
+      aliases.each do |shortcut, command|
+        it "'#{shortcut}' for '#{command}'" do
+          expect(git_config).to contain "alias.#{shortcut}=#{command}"
+        end
+      end
     end
   end
 end

--- a/cookbooks/vm/spec/integration/recipes/git_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/git_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'vm::git' do
+
+  it 'installs git' do
+    expect(package('git')).to be_installed
+    expect(command('git --version').exit_status).to eq 0
+  end
+
+  it 'installs meld as the diff / merge tool' do
+    expect(package('meld')).to be_installed
+    expect(command('meld --version').exit_status).to eq 0
+  end
+
+  context '~/.gitconfig' do
+    it 'configures meld as the difftool' do
+      expect(command('meld --version').exit_status).to eq 0
+    end
+    it 'configures meld as the mergetool' do
+      expect(command('meld --version').exit_status).to eq 0
+    end
+  end
+end

--- a/cookbooks/vm/templates/default/git_config.erb
+++ b/cookbooks/vm/templates/default/git_config.erb
@@ -1,0 +1,27 @@
+[core]
+  autocrlf = input
+[push]
+  default = simple
+[diff]
+  tool = meld
+[difftool]
+  prompt = false
+[difftool "meld"]
+  trustExitCode = false
+[merge]
+  tool = meld
+[mergetool]
+  prompt = false
+[mergetool "meld"]
+  trustExitCode = false
+  keepBackup = false
+[alias]
+  co = checkout
+  ci = commit
+  br = branch
+  st = status
+  unstage = reset HEAD --
+  slog = log --pretty=oneline --abbrev-commit
+[http]
+  sslVerify = false
+  # proxy = http://your.proxy.org:8080


### PR DESCRIPTION
Adds an initial `~/.gitconfig` file:

 * with some useful aliases defined
 * with `meld` configured for diffing / merging 
 