### PR TITLE
Gitconfig improvements

### DIFF
--- a/cookbooks/vm/templates/default/git_config.erb
+++ b/cookbooks/vm/templates/default/git_config.erb
@@ -23,6 +23,8 @@
   unstage = reset HEAD --
   slog = log --pretty=oneline --abbrev-commit
   graph = log --all --oneline --graph --decorate
+[push]
+  default = simple
 [http]
   sslVerify = false
   # proxy = http://your.proxy.org:8080

--- a/cookbooks/vm/templates/default/git_config.erb
+++ b/cookbooks/vm/templates/default/git_config.erb
@@ -22,6 +22,7 @@
   st = status
   unstage = reset HEAD --
   slog = log --pretty=oneline --abbrev-commit
+  graph = log --all --oneline --graph --decorate
 [http]
   sslVerify = false
   # proxy = http://your.proxy.org:8080


### PR DESCRIPTION
Improve the `.gitconfig`:

 * explicitly adopt the new Git 2.0 push behaviour (`push.default = simple`) to get rid of the warning message
 * add `git graph` alias to show the commit graph / branches on the commandline without a GUI tool

See also:
https://github.com/tknerr/bills-kitchen/pull/133