### PR TITLE
Make the Atom plugins installation idempotent

### DIFF
--- a/cookbooks/vm/libraries/helpers.rb
+++ b/cookbooks/vm/libraries/helpers.rb
@@ -47,5 +47,22 @@ class Chef
                environment: devbox_user_env
       end
     end
+
+    #
+    # atom_apm does not work, so we use a bash resource, see
+    # https://github.com/mohitsethi/chef-atom/issues/2
+    #
+    def install_atom_plugin(name)
+      bash "install atom plugin #{name} for #{devbox_user}" do
+        user devbox_user
+        group devbox_group
+        environment devbox_user_env
+        code "apm install #{name}"
+        not_if "apm list --installed --bare | grep -q '#{name}@'",
+               user: devbox_user,
+               group: devbox_group,
+               environment: devbox_user_env
+      end
+    end
   end
 end

--- a/cookbooks/vm/libraries/helpers.rb
+++ b/cookbooks/vm/libraries/helpers.rb
@@ -52,13 +52,13 @@ class Chef
     # atom_apm does not work, so we use a bash resource, see
     # https://github.com/mohitsethi/chef-atom/issues/2
     #
-    def install_atom_plugin(name)
-      bash "install atom plugin #{name} for #{devbox_user}" do
+    def install_atom_plugin(name, version)
+      bash "install atom plugin #{name}@#{version} for #{devbox_user}" do
         user devbox_user
         group devbox_group
         environment devbox_user_env
-        code "apm install #{name}"
-        not_if "apm list --installed --bare | grep -q '#{name}@'",
+        code "apm install #{name}@#{version}"
+        not_if "apm list --installed --bare | grep -q '#{name}@#{version}'",
                user: devbox_user,
                group: devbox_group,
                environment: devbox_user_env

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -21,15 +21,15 @@ bash 'install-atom' do
 end
 
 # install plugins
-plugins = %w(
-  atom-beautify
-  minimap
-  line-ending-converter
-  language-chef
-  language-batchfile
-)
-plugins.each do |plugin|
-  install_atom_plugin(plugin)
+plugins = {
+  'atom-beautify' => '0.29.7',
+  'minimap' => '4.23.5',
+  'line-ending-converter' => '1.3.2',
+  'language-chef' => '0.9.0',
+  'language-batchfile' => '0.4.0'
+}
+plugins.each do |name, version|
+  install_atom_plugin(name, version)
 end
 
 # config tweaks

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -29,14 +29,7 @@ plugins = %w(
   language-batchfile
 )
 plugins.each do |plugin|
-  # atom_apm does not work, so we use a bash resource, see
-  # https://github.com/mohitsethi/chef-atom/issues/2
-  bash "install-#{plugin}-atom-plugin" do
-    environment devbox_user_env
-    user devbox_user
-    group devbox_group
-    code "apm install #{plugin}"
-  end
+  install_atom_plugin(plugin)
 end
 
 # config tweaks

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -5,18 +5,28 @@ describe 'vm::atom' do
 
   let(:atom_version) { devbox_user_gui_command('atom -v').stdout }
   let(:atom_config) { file('/home/vagrant/.atom/config.cson') }
-  let(:installed_plugins) { devbox_user_command('apm list -i').stdout }
+  let(:installed_plugins) { devbox_user_command('apm list -i -b').stdout }
 
   it 'installs atom 1.7.3' do
     expect(atom_version).to contain '1.7.3'
   end
 
-  it 'installs some useful atom plugins' do
-    expect(installed_plugins).to contain 'atom-beautify'
-    expect(installed_plugins).to contain 'minimap'
-    expect(installed_plugins).to contain 'line-ending-converter'
-    expect(installed_plugins).to contain 'language-chef'
-    expect(installed_plugins).to contain 'language-batchfile'
+  describe 'plugins' do
+    it 'installs "atom-beautify" plugin 0.29.7' do
+      expect(installed_plugins).to contain 'atom-beautify@0.29.7'
+    end
+    it 'installs "minimap" plugin 4.23.5' do
+      expect(installed_plugins).to contain 'minimap@4.23.5'
+    end
+    it 'installs "line-ending-converter" plugin 1.3.2' do
+      expect(installed_plugins).to contain 'line-ending-converter@1.3.2'
+    end
+    it 'installs "language-chef" plugin 0.9.0' do
+      expect(installed_plugins).to contain 'language-chef@0.9.0'
+    end
+    it 'installs "language-batchfile" plugin 0.4.0' do
+      expect(installed_plugins).to contain 'language-batchfile@0.4.0'
+    end
   end
 
   it 'configures atom to have sublime tabs behaviour' do

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -12,19 +12,19 @@ describe 'vm::atom' do
   end
 
   describe 'plugins' do
-    it 'installs "atom-beautify" plugin 0.29.7' do
+    it 'installs "atom-beautify" plugin v0.29.7' do
       expect(installed_plugins).to contain 'atom-beautify@0.29.7'
     end
-    it 'installs "minimap" plugin 4.23.5' do
+    it 'installs "minimap" plugin v4.23.5' do
       expect(installed_plugins).to contain 'minimap@4.23.5'
     end
-    it 'installs "line-ending-converter" plugin 1.3.2' do
+    it 'installs "line-ending-converter" plugin v1.3.2' do
       expect(installed_plugins).to contain 'line-ending-converter@1.3.2'
     end
-    it 'installs "language-chef" plugin 0.9.0' do
+    it 'installs "language-chef" plugin v0.9.0' do
       expect(installed_plugins).to contain 'language-chef@0.9.0'
     end
-    it 'installs "language-batchfile" plugin 0.4.0' do
+    it 'installs "language-batchfile" plugin v0.4.0' do
       expect(installed_plugins).to contain 'language-batchfile@0.4.0'
     end
   end

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -13,19 +13,21 @@ describe 'vm::vagrant' do
     expect(devbox_user_command('echo $VAGRANT_DEFAULT_PROVIDER').stdout.strip).to eq 'docker'
   end
 
-  it 'installs "vagrant-cachier" plugin 1.2.1' do
-    expect(installed_plugins).to include 'vagrant-cachier (1.2.1)'
-  end
-  it 'installs "vagrant-berkshelf" plugin 4.1.0' do
-    expect(installed_plugins).to include 'vagrant-berkshelf (4.1.0)'
-  end
-  it 'installs "vagrant-omnibus" plugin 1.4.1' do
-    expect(installed_plugins).to include 'vagrant-omnibus (1.4.1)'
-  end
-  it 'installs "vagrant-toplevel-cookbooks" plugin 0.2.4' do
-    expect(installed_plugins).to include 'vagrant-toplevel-cookbooks (0.2.4)'
-  end
-  it 'installs "vagrant-lxc" plugin 1.1.0' do
-    expect(installed_plugins).to include 'vagrant-lxc (1.1.0)'
+  describe 'plugins' do
+    it 'installs "vagrant-cachier" plugin v1.2.1' do
+      expect(installed_plugins).to include 'vagrant-cachier (1.2.1)'
+    end
+    it 'installs "vagrant-berkshelf" plugin v4.1.0' do
+      expect(installed_plugins).to include 'vagrant-berkshelf (4.1.0)'
+    end
+    it 'installs "vagrant-omnibus" plugin v1.4.1' do
+      expect(installed_plugins).to include 'vagrant-omnibus (1.4.1)'
+    end
+    it 'installs "vagrant-toplevel-cookbooks" plugin v0.2.4' do
+      expect(installed_plugins).to include 'vagrant-toplevel-cookbooks (0.2.4)'
+    end
+    it 'installs "vagrant-lxc" plugin v1.1.0' do
+      expect(installed_plugins).to include 'vagrant-lxc (1.1.0)'
+    end
   end
 end


### PR DESCRIPTION
So far the atom plugins had always been reinstalled with every chef run.

With this PR this is no longer the case, ie atom plugins will only be reinstalled if not already present. Also the atom plugins are now version pinned.