### PR TITLE
Ensuring that build-essentials package is present

### DIFF
--- a/cookbooks/vm/recipes/base.rb
+++ b/cookbooks/vm/recipes/base.rb
@@ -8,6 +8,6 @@ end
 
 include_recipe 'apt'
 
-%w( vim git libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev ).each do |pkg|
+%w( vim git libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential ).each do |pkg|
   package pkg
 end


### PR DESCRIPTION
Otherwise the installation of ChefDK fails inside the container -- looks like `make` is present in the virtualbox basebox but not in the docker baseimage.

Adding `build-essential` package ensure it is there in either case