### PR TITLE
Update to latest ChefDK 1.3.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Major update:
 
  * update to Ubuntu 16.04 basebox (see [PR #29](https://github.com/tknerr/linus-kitchen/pull/29))
+ * update to ChefDK 1.3.32 (see [PR #32](https://github.com/tknerr/linus-kitchen/pull/32))
 
 ## 0.1 (May 11, 2016)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ should see all tests passing:
 ==> default:
 ==> default: update-vm.sh
 ==> default:   installs git
-==> default:   installs chefdk 0.7.0
+==> default:   installs chefdk 1.3.32
 ==> default:
 ==> default: Finished in 24.44 seconds (files took 0.81272 seconds to load)
 ==> default: 33 examples, 0 failures

--- a/cookbooks/vm/.rubocop.yml
+++ b/cookbooks/vm/.rubocop.yml
@@ -1,6 +1,10 @@
 Metrics/LineLength:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+
 Style/EmptyLinesAroundBlockBody:
   Enabled: false
 

--- a/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
+++ b/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
@@ -9,7 +9,7 @@ describe 'update-vm.sh' do
     expect(command('git --version').exit_status).to eq 0
   end
 
-  it 'installs chefdk 1.2.22' do
-    expect(command('chef --version').stdout).to contain 'Chef Development Kit Version: 1.2.22'
+  it 'installs chefdk 1.3.32' do
+    expect(command('chef --version').stdout).to contain 'Chef Development Kit Version: 1.3.32'
   end
 end

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CHEFDK_VERSION="1.2.22"
+CHEFDK_VERSION="1.3.32"
 TARGET_DIR="/tmp/vagrant-cache/wget"
 REPO_ROOT="/home/vagrant/vm-setup"
 
@@ -34,7 +34,7 @@ check_chefdk() {
     step "Downloading and installing ChefDK $CHEFDK_VERSION"
     mkdir -p $TARGET_DIR
     wget --no-verbose --no-clobber -O $TARGET_DIR/chefdk_$CHEFDK_VERSION-1_amd64.deb \
-      https://packages.chef.io/files/stable/chefdk/$CHEFDK_VERSION/ubuntu/16.04/chefdk_$CHEFDK_VERSION-1_amd64.deb
+      https://packages.chef.io/files/current/chefdk/$CHEFDK_VERSION/ubuntu/16.04/chefdk_$CHEFDK_VERSION-1_amd64.deb
     sudo dpkg -i $TARGET_DIR/chefdk_$CHEFDK_VERSION-1_amd64.deb
   fi
 }


### PR DESCRIPTION
Use the bleeding edge ChefDK version which is also supposed to fix the annoying warnings in the Chef run output (hashie gem related)