### PR TITLE
Update Vagrant to v1.9.3 and plugins to their latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Major update:
 
  * update to Ubuntu 16.04 basebox (see [PR #29](https://github.com/tknerr/linus-kitchen/pull/29))
  * update to ChefDK 1.3.32 (see [PR #32](https://github.com/tknerr/linus-kitchen/pull/32))
+ * update Vagrant to v1.9.3 and plugins (see [PR #33](https://github.com/tknerr/linus-kitchen/pull/33)):
+    * vagrant-omnibus to v1.5.0
+    * vagrant-berkshelf to v5.1.1
+    * vagrant-lxc to v1.2.3
 
 ## 0.1 (May 11, 2016)
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,8 @@ dependencies:
   cache_directories:
     - ~/.vagrant.d
   pre:
-    - wget https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb
-    - sudo dpkg -i vagrant_1.8.1_x86_64.deb
+    - wget https://releases.hashicorp.com/vagrant/1.9.3/vagrant_1.9.3_x86_64.deb
+    - sudo dpkg -i vagrant_1.9.3_x86_64.deb
 
 test:
   override:

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -1,6 +1,6 @@
 
-node.set['vagrant']['url'] = 'https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_x86_64.deb'
-node.set['vagrant']['checksum'] = 'ed0e1ae0f35aecd47e0b3dfb486a230984a08ceda3b371486add4d42714a693d'
+node.set['vagrant']['url'] = 'https://releases.hashicorp.com/vagrant/1.9.3/vagrant_1.9.3_x86_64.deb'
+node.set['vagrant']['checksum'] = 'faff6befacc7eed3978b4b71f0dbb9c135c01d8a4d13236bda2f9ed53482d2c4'
 
 include_recipe 'vagrant'
 

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -6,7 +6,7 @@ include_recipe 'vagrant'
 
 install_vagrant_plugin 'vagrant-cachier', '1.2.1'
 install_vagrant_plugin 'vagrant-berkshelf', '5.1.1'
-install_vagrant_plugin 'vagrant-omnibus', '1.4.1'
+install_vagrant_plugin 'vagrant-omnibus', '1.5.0'
 install_vagrant_plugin 'vagrant-toplevel-cookbooks', '0.2.4'
 install_vagrant_plugin 'vagrant-lxc', '1.1.0'
 

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -5,7 +5,7 @@ node.set['vagrant']['checksum'] = 'faff6befacc7eed3978b4b71f0dbb9c135c01d8a4d132
 include_recipe 'vagrant'
 
 install_vagrant_plugin 'vagrant-cachier', '1.2.1'
-install_vagrant_plugin 'vagrant-berkshelf', '4.1.0'
+install_vagrant_plugin 'vagrant-berkshelf', '5.1.1'
 install_vagrant_plugin 'vagrant-omnibus', '1.4.1'
 install_vagrant_plugin 'vagrant-toplevel-cookbooks', '0.2.4'
 install_vagrant_plugin 'vagrant-lxc', '1.1.0'

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -8,7 +8,7 @@ install_vagrant_plugin 'vagrant-cachier', '1.2.1'
 install_vagrant_plugin 'vagrant-berkshelf', '5.1.1'
 install_vagrant_plugin 'vagrant-omnibus', '1.5.0'
 install_vagrant_plugin 'vagrant-toplevel-cookbooks', '0.2.4'
-install_vagrant_plugin 'vagrant-lxc', '1.1.0'
+install_vagrant_plugin 'vagrant-lxc', '1.2.3'
 
 bashd_entry 'set-vagrant-default-provider' do
   user devbox_user

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -20,8 +20,8 @@ describe 'vm::vagrant' do
     it 'installs "vagrant-berkshelf" plugin v5.1.1' do
       expect(installed_plugins).to include 'vagrant-berkshelf (5.1.1)'
     end
-    it 'installs "vagrant-omnibus" plugin v1.4.1' do
-      expect(installed_plugins).to include 'vagrant-omnibus (1.4.1)'
+    it 'installs "vagrant-omnibus" plugin v1.5.0' do
+      expect(installed_plugins).to include 'vagrant-omnibus (1.5.0)'
     end
     it 'installs "vagrant-toplevel-cookbooks" plugin v0.2.4' do
       expect(installed_plugins).to include 'vagrant-toplevel-cookbooks (0.2.4)'

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -5,8 +5,8 @@ describe 'vm::vagrant' do
   let(:vagrant_version) { devbox_user_command('vagrant -v').stdout.strip }
   let(:installed_plugins) { devbox_user_command('vagrant plugin list').stdout }
 
-  it 'installs vagrant 1.8.1' do
-    expect(vagrant_version).to match 'Vagrant 1.8.1'
+  it 'installs vagrant 1.9.3' do
+    expect(vagrant_version).to match 'Vagrant 1.9.3'
   end
 
   it 'configures "docker" as the $VAGRANT_DEFAULT_PROVIDER' do

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -17,8 +17,8 @@ describe 'vm::vagrant' do
     it 'installs "vagrant-cachier" plugin v1.2.1' do
       expect(installed_plugins).to include 'vagrant-cachier (1.2.1)'
     end
-    it 'installs "vagrant-berkshelf" plugin v4.1.0' do
-      expect(installed_plugins).to include 'vagrant-berkshelf (4.1.0)'
+    it 'installs "vagrant-berkshelf" plugin v5.1.1' do
+      expect(installed_plugins).to include 'vagrant-berkshelf (5.1.1)'
     end
     it 'installs "vagrant-omnibus" plugin v1.4.1' do
       expect(installed_plugins).to include 'vagrant-omnibus (1.4.1)'

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -26,8 +26,8 @@ describe 'vm::vagrant' do
     it 'installs "vagrant-toplevel-cookbooks" plugin v0.2.4' do
       expect(installed_plugins).to include 'vagrant-toplevel-cookbooks (0.2.4)'
     end
-    it 'installs "vagrant-lxc" plugin v1.1.0' do
-      expect(installed_plugins).to include 'vagrant-lxc (1.1.0)'
+    it 'installs "vagrant-lxc" plugin v1.2.3' do
+      expect(installed_plugins).to include 'vagrant-lxc (1.2.3)'
     end
   end
 end


### PR DESCRIPTION
Updates:

 * vagrant to v1.9.3
 * vagrant-omnibus to v1.5.0
 * vagrant-berkshelf to v5.1.1
 * vagrant-lxc to v1.2.3

Also uses the latest vagrant 1.9.3 now for building on circleci