### PR TITLE
Update to latest docker-engine 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Major update:
     * vagrant-omnibus to v1.5.0
     * vagrant-berkshelf to v5.1.1
     * vagrant-lxc to v1.2.3
+ * update to Docker 1.13.1 (see [PR #34](https://github.com/tknerr/linus-kitchen/pull/34))
 
 ## 0.1 (May 11, 2016)
 

--- a/cookbooks/vm/recipes/docker.rb
+++ b/cookbooks/vm/recipes/docker.rb
@@ -14,14 +14,14 @@ end
 if docker?
   # only install docker, don't try to start the deamon
   docker_installation_package 'default' do
-    version '1.11.0'
+    version '1.13.1'
     action :create
   end
 else
   # install docker and start the docker deamon
   docker_service 'default' do
     install_method 'package'
-    version '1.11.0'
+    version '1.13.1'
     action [:create, :start]
   end
 end

--- a/cookbooks/vm/spec/integration/recipes/docker_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/docker_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'vm::docker' do
 
-  it 'installs docker 1.11' do
-    expect(devbox_user_command('docker -v').stdout).to match 'Docker version 1.11'
+  it 'installs docker 1.13.1' do
+    expect(devbox_user_command('docker -v').stdout).to match 'Docker version 1.13.1'
   end
 
   it 'adds the devbox user to the docker group' do


### PR DESCRIPTION
Updates to the latest available version of `docker-engine` v1.13.1

Note: since a couple of weeks docker uses a new versioning scheme and is available als `docker-ce` (community edition) and `docker-ee` (enterprise edition) variants. Since this is not supported in the chef-docker cookbook yet (see https://github.com/chef-cookbooks/docker/issues/835), we remain at the latest docker-engine version for now
