### PR TITLE
Update Atom Editor (to v1.15.0) and Plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Updated tools:
     * vagrant-berkshelf to v5.1.1
     * vagrant-lxc to v1.2.3
  * update to Docker 1.13.1 (see [PR #34](https://github.com/tknerr/linus-kitchen/pull/34))
+ * update to Atom Editor v1.15.0 and plugins (see [PR #35](https://github.com/tknerr/linus-kitchen/pull/35)):
+    * atom-beautify to v0.29.18
+    * atom-minimap to v4.27.1
+    * removed: language-batchfile (not needed)
+    * removed: line-ending-converter (part of atom core)
+
 
 Newly installed tools:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Other tweaks worth mentioning:
  * Pre-installed Atom plugins:
    * [atom-beautify](https://atom.io/packages/atom-beautify) - code formatter / beautifier for various languages
    * [minimap](https://atom.io/packages/minimap) - a SublimeText like minimap
-   * [line-ending-converter](https://atom.io/packages/line-ending-converter) - show and convert between line ending styles
    * [language-chef](https://atom.io/packages/language-chef) - code snippets for Chef recipes
  * Symlinked [`update-vm.sh`](scripts/update-vm.sh) to `/usr/local/bin/update-vm` so it's in the `$PATH` and can be used for updating the VM from the inside (see below)
 

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -24,8 +24,7 @@ end
 plugins = {
   'atom-beautify' => '0.29.18',
   'minimap' => '4.27.1',
-  'language-chef' => '0.9.0',
-  'language-batchfile' => '0.4.0'
+  'language-chef' => '0.9.0'
 }
 plugins.each do |name, version|
   install_atom_plugin(name, version)

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -26,7 +26,7 @@ end
 # install plugins
 plugins = {
   'atom-beautify' => '0.29.18',
-  'minimap' => '4.23.5',
+  'minimap' => '4.27.1',
   'line-ending-converter' => '1.3.2',
   'language-chef' => '0.9.0',
   'language-batchfile' => '0.4.0'

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -27,7 +27,6 @@ end
 plugins = {
   'atom-beautify' => '0.29.18',
   'minimap' => '4.27.1',
-  'line-ending-converter' => '1.3.2',
   'language-chef' => '0.9.0',
   'language-batchfile' => '0.4.0'
 }

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -3,8 +3,6 @@ atom_version = '1.15.0'
 atom_deb_file = "atom-v#{atom_version}-amd64.deb"
 
 if docker?
-  # we need libasound2 for starting atom in docker
-  package 'libasound2'
   # avoid /dev/fuse issues on circleci
   extra_options = '--no-install-recommends'
 end

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -1,4 +1,7 @@
 
+atom_version = '1.15.0'
+atom_deb_file = "atom-v#{atom_version}-amd64.deb"
+
 if docker?
   # we need xvfb + libasound2 for starting atom in docker
   package 'xvfb'
@@ -8,16 +11,16 @@ if docker?
 end
 
 # install atom
-remote_file "#{Chef::Config[:file_cache_path]}/atom-1.7.3-amd64.deb" do
-  source 'https://github.com/atom/atom/releases/download/v1.7.3/atom-amd64.deb'
+remote_file "#{Chef::Config[:file_cache_path]}/#{atom_deb_file}" do
+  source "https://github.com/atom/atom/releases/download/v#{atom_version}/atom-amd64.deb"
   mode '0644'
 end
 bash 'install-atom-with-dependencies' do
   code <<-EOF
-    dpkg -i #{Chef::Config[:file_cache_path]}/atom-1.7.3-amd64.deb
+    dpkg -i #{Chef::Config[:file_cache_path]}/#{atom_deb_file}
     apt-get -y --fix-broken install #{extra_options}
     EOF
-  not_if "which atom && #{docker? ? 'xvfb-run' : 'DISPLAY=:0'} atom -v | grep -q '1.7.3'"
+  not_if "which atom && #{docker? ? 'xvfb-run' : 'DISPLAY=:0'} atom -v | grep -q '#{atom_version}'"
 end
 
 # install plugins

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -3,8 +3,7 @@ atom_version = '1.15.0'
 atom_deb_file = "atom-v#{atom_version}-amd64.deb"
 
 if docker?
-  # we need xvfb + libasound2 for starting atom in docker
-  package 'xvfb'
+  # we need libasound2 for starting atom in docker
   package 'libasound2'
   # avoid /dev/fuse issues on circleci
   extra_options = '--no-install-recommends'
@@ -20,7 +19,7 @@ bash 'install-atom-with-dependencies' do
     dpkg -i #{Chef::Config[:file_cache_path]}/#{atom_deb_file}
     apt-get -y --fix-broken install #{extra_options}
     EOF
-  not_if "which atom && #{docker? ? 'xvfb-run' : 'DISPLAY=:0'} atom -v | grep -q '#{atom_version}'"
+  not_if "which atom && xvfb-run atom -v | grep -q '#{atom_version}'"
 end
 
 # install plugins

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -3,6 +3,8 @@ atom_version = '1.15.0'
 atom_deb_file = "atom-v#{atom_version}-amd64.deb"
 
 if docker?
+  # we need libxss-dev for starting atom in docker
+  package 'libxss-dev'
   # avoid /dev/fuse issues on circleci
   extra_options = '--no-install-recommends'
 end

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -25,7 +25,7 @@ end
 
 # install plugins
 plugins = {
-  'atom-beautify' => '0.29.7',
+  'atom-beautify' => '0.29.18',
   'minimap' => '4.23.5',
   'line-ending-converter' => '1.3.2',
   'language-chef' => '0.9.0',

--- a/cookbooks/vm/recipes/base.rb
+++ b/cookbooks/vm/recipes/base.rb
@@ -2,6 +2,6 @@
 include_recipe 'apt'
 include_recipe 'chef-sugar'
 
-%w(vim git libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential).each do |pkg|
+%w(vim git libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb).each do |pkg|
   package pkg
 end

--- a/cookbooks/vm/recipes/git.rb
+++ b/cookbooks/vm/recipes/git.rb
@@ -1,7 +1,5 @@
 
 if docker?
-  # we need xvfb for starting meld in docker
-  package 'xvfb'
   # avoid /dev/fuse issues on circleci
   extra_options = '--no-install-recommends'
 end

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -6,8 +6,8 @@ describe 'vm::atom' do
   let(:atom_config) { file('/home/vagrant/.atom/config.cson') }
   let(:installed_plugins) { devbox_user_command('apm list -i -b').stdout }
 
-  it 'installs atom 1.7.3' do
-    expect(atom_version).to contain '1.7.3'
+  it 'installs atom 1.15.0' do
+    expect(atom_version).to contain '1.15.0'
   end
 
   describe 'plugins' do

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -17,9 +17,6 @@ describe 'vm::atom' do
     it 'installs "minimap" plugin v4.27.1' do
       expect(installed_plugins).to contain 'minimap@4.27.1'
     end
-    it 'installs "line-ending-converter" plugin v1.3.2' do
-      expect(installed_plugins).to contain 'line-ending-converter@1.3.2'
-    end
     it 'installs "language-chef" plugin v0.9.0' do
       expect(installed_plugins).to contain 'language-chef@0.9.0'
     end

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -11,8 +11,8 @@ describe 'vm::atom' do
   end
 
   describe 'plugins' do
-    it 'installs "atom-beautify" plugin v0.29.7' do
-      expect(installed_plugins).to contain 'atom-beautify@0.29.7'
+    it 'installs "atom-beautify" plugin v0.29.18' do
+      expect(installed_plugins).to contain 'atom-beautify@0.29.18'
     end
     it 'installs "minimap" plugin v4.23.5' do
       expect(installed_plugins).to contain 'minimap@4.23.5'

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -20,9 +20,6 @@ describe 'vm::atom' do
     it 'installs "language-chef" plugin v0.9.0' do
       expect(installed_plugins).to contain 'language-chef@0.9.0'
     end
-    it 'installs "language-batchfile" plugin v0.4.0' do
-      expect(installed_plugins).to contain 'language-batchfile@0.4.0'
-    end
   end
 
   it 'configures atom to have sublime tabs behaviour' do

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -14,8 +14,8 @@ describe 'vm::atom' do
     it 'installs "atom-beautify" plugin v0.29.18' do
       expect(installed_plugins).to contain 'atom-beautify@0.29.18'
     end
-    it 'installs "minimap" plugin v4.23.5' do
-      expect(installed_plugins).to contain 'minimap@4.23.5'
+    it 'installs "minimap" plugin v4.27.1' do
+      expect(installed_plugins).to contain 'minimap@4.27.1'
     end
     it 'installs "line-ending-converter" plugin v1.3.2' do
       expect(installed_plugins).to contain 'line-ending-converter@1.3.2'

--- a/cookbooks/vm/spec/spec_helper.rb
+++ b/cookbooks/vm/spec/spec_helper.rb
@@ -9,11 +9,7 @@ end
 
 # for runnig commands which expect an X environment
 def devbox_user_gui_command(cmd)
-  if in_docker?
-    devbox_user_command "xvfb-run #{cmd}"
-  else
-    devbox_user_command "DISPLAY=:0 #{cmd}"
-  end
+  devbox_user_command "xvfb-run #{cmd}"
 end
 
 # see https://github.com/sethvargo/chef-sugar/blob/v3.4.0/lib/chef/sugar/docker.rb#L31


### PR DESCRIPTION
This PR:

 * updates Atom to v1.15.0
 * updates plugins:
    * atom-beautify to v0.29.18
    * atom-minimap to v4.27.1
    * removed: language-batchfile (not needed)
    * removed: line-ending-converter (part of atom core)

It also installs `xvfb` by default now since we need it for testing gui applications. Our previous approach using `$DISPLAY` env var was brittle and worked only if the setup user was actually logged in a GUI session (i.e. would not have worked in headless mode). Using `xvfb-run` this now works reliably and also makes the code more simple.