### PR TITLE
Install the systemload indicator applet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Newly installed tools:
 
  * installs VirtualBox 5.1.18 and make it the default vagrant provider (see [PR #28](https://github.com/tknerr/linus-kitchen/pull/28))
  * installs Packer 1.0.0 (see [PR #36](https://github.com/tknerr/linus-kitchen/pull/36))
+ * installs the indicator-multiload applet for monitoring system resources (see [PR #37](https://github.com/tknerr/linus-kitchen/pull/37))
 
 
 ## 0.1 (May 11, 2016)

--- a/cookbooks/vm/recipes/base.rb
+++ b/cookbooks/vm/recipes/base.rb
@@ -2,6 +2,6 @@
 include_recipe 'apt'
 include_recipe 'chef-sugar'
 
-%w(vim git libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb).each do |pkg|
+%w(vim git libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb indicator-multiload).each do |pkg|
   package pkg
 end

--- a/cookbooks/vm/spec/integration/recipes/base_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/base_spec.rb
@@ -15,4 +15,8 @@ describe 'vm::base' do
     end
   end
 
+  it 'installs the multiload indicator' do
+    expect(package('indicator-multiload')).to be_installed
+  end
+
 end


### PR DESCRIPTION
installs the `indicator-multiload` applet for monitoring CPU / RAM / Disk / Network from the top panel

![image](https://cloud.githubusercontent.com/assets/365744/24980060/d46c18cc-1fd6-11e7-97c6-51afc3b4310c.png)
