### PR TITLE
Fix various minor glitches when provisioning the VM via Vagrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,18 @@ Updated tools:
     * removed: language-batchfile (not needed)
     * removed: line-ending-converter (part of atom core)
 
-
 Newly installed tools:
 
  * installs VirtualBox 5.1.18 and make it the default vagrant provider (see [PR #28](https://github.com/tknerr/linus-kitchen/pull/28))
  * installs Packer 1.0.0 (see [PR #36](https://github.com/tknerr/linus-kitchen/pull/36))
  * installs the indicator-multiload applet for monitoring system resources (see [PR #37](https://github.com/tknerr/linus-kitchen/pull/37))
 
+Improvements:
+
+ * various minor improvements when provisioning via Vagrant (see [PR #39](https://github.com/tknerr/linus-kitchen/pull/39)):
+    * use all available CPU cores when starting the VM via vagrant
+    * force colored output when provisioning the VM without a tty
+    * adjust chef-zero log level when provisioning the VM without a tty
 
 ## 0.1 (May 11, 2016)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant::configure("2") do |config|
     vbox.customize ["modifyvm", :id,
       "--name", "Linus Kitchen",
       "--memory", 4096,
-      "--cpus", 4
+      "--cpus", Etc.nprocessors
     ]
     # yes we have a gui
     vbox.gui = true
@@ -22,7 +22,7 @@ Vagrant::configure("2") do |config|
   [ :vmware_workstation, :vmware_fusion ].each do |vmware_provider|
     config.vm.provider vmware_provider do |vmware, override|
       vmware.vmx["displayname"] = "Linus Kitchen"
-      vmware.vmx["numvcpus"] = "4"
+      vmware.vmx["numvcpus"] = "#{Etc.nprocessors}"
       vmware.vmx["memsize"] = "4096"
       vmware.vmx["mouse.vusb.startConnected"] = "FALSE"
       vmware.vmx["vhv.enable"] = "TRUE"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,7 @@ Vagrant::configure("2") do |config|
   end
 
   # Install ChefDK and trigger the Chef run from within the VM
-  config.vm.provision "shell", privileged: false, inline: "/vagrant/scripts/update-vm.sh"
+  config.vm.provision "shell", privileged: false, keep_color: true, inline: "/vagrant/scripts/update-vm.sh"
   # Logout any existing GUI session to force the use to re-login, which is required
   # for group or keyboard layout changes to take effect
   config.vm.provision "shell", privileged: true, inline: "pkill -KILL -u vagrant; true"

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -99,7 +99,7 @@ verify_vm() {
 
   # run lint checks
   step "run codestyle checks"
-  rubocop . --format progress --format offenses --display-cop-names
+  rubocop . --format progress --format offenses --display-cop-names --color
   foodcritic -f any .
 
   # run integration tests

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -104,7 +104,7 @@ verify_vm() {
 
   # run integration tests
   step "run integration tests"
-  rspec --require rspec_junit_formatter --format doc --color --format RspecJunitFormatter --out test/junit-report.xml --format html --out test/test-report.html
+  rspec --require rspec_junit_formatter --format doc --color --tty --format RspecJunitFormatter --out test/junit-report.xml --format html --out test/test-report.html
 }
 
 #

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -88,7 +88,7 @@ update_vm() {
 
   # converge the system via chef-zero
   step "trigger the chef-zero run"
-  sudo chef-client --local-mode --format=doc --force-formatter --color --runlist=vm
+  sudo chef-client --local-mode --format=doc --force-formatter --log_level=warn --color --runlist=vm
 }
 
 verify_vm() {


### PR DESCRIPTION
Improvements to make the `vagrant provision` experience better and make the output look closer to the output from running `update-vm` within the VM GUI session:

 * use all available CPU cores when starting the VM via vagrant
 * force colored output when provisioning the VM without a tty
 * adjust chef-zero log level when provisioning the VM without a tty

The differences mostly come from the fact that `vagrant provision` runs via a non-interactive shell where stdout is sent via ssh and not to a tty. This makes tools behave differently and requires us to explicitly force colored output or adjust log levels.