### PR TITLE
Improve chef-zero startup time by disabling the vmware ohai plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Improvements:
     * use all available CPU cores when starting the VM via vagrant
     * force colored output when provisioning the VM without a tty
     * adjust chef-zero log level when provisioning the VM without a tty
+ * noticeably improve chef-zero startup time by disabling the vmware ohai plugin (see [PR #40](https://github.com/tknerr/linus-kitchen/pull/40))
 
 ## 0.1 (May 11, 2016)
 

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -86,6 +86,9 @@ update_vm() {
   rm -rf ./cookbooks
   berks vendor ./cookbooks
 
+  # disable vmware ohai plugin because it's so painfully slow
+  sudo find /opt/chefdk/embedded/ -wholename *ohai* -name vmware.rb -exec mv {} {}.disabled \;
+
   # converge the system via chef-zero
   step "trigger the chef-zero run"
   sudo chef-client --local-mode --format=doc --force-formatter --log_level=warn --color --runlist=vm


### PR DESCRIPTION
Wondering why `chef-zero` takes so long to start up?

With debug logging enabled you can see that it is the `vmware.rb` ohai plugin which eats about ~15s during chef-zero startup:

```
==> default: [2017-04-13T06:29:00+00:00] DEBUG: Plugin Sessions: ran '/bin/loginctl --no-pager --no-legend --no-ask-password list-sessions' and returned 0
==> default: [2017-04-13T06:29:00+00:00] DEBUG: Plugin Hostnamectl: found hostnamectl at /usr/bin/hostnamectl
==> default: [2017-04-13T06:29:00+00:00] DEBUG: Plugin Hostnamectl: ran '/usr/bin/hostnamectl' and returned 0
==> default: [2017-04-13T06:29:00+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd stat hosttime' and returned 0
==> default: [2017-04-13T06:29:00+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd stat speed' and returned 0
==> default: [2017-04-13T06:29:02+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd stat sessionid' and returned 75
==> default: [2017-04-13T06:29:04+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd stat balloon' and returned 75
==> default: [2017-04-13T06:29:06+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd stat swap' and returned 75
==> default: [2017-04-13T06:29:08+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd stat memlimit' and returned 75
==> default: [2017-04-13T06:29:10+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd stat memres' and returned 75
==> default: [2017-04-13T06:29:12+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd stat cpures' and returned 75
==> default: [2017-04-13T06:29:15+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd stat cpulimit' and returned 75
==> default: [2017-04-13T06:29:15+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd upgrade status' and returned 64
==> default: [2017-04-13T06:29:15+00:00] DEBUG: Plugin VMware: ran '/usr/bin/vmware-toolbox-cmd timesync status' and returned 0
==> default: [2017-04-13T06:29:15+00:00] DEBUG: Plugin Virtualbox: ran 'VBoxControl guestproperty enumerate' and failed #<Errno::ENOENT: No such file or directory - VBoxControl>
==> default: [2017-04-13T06:29:15+00:00] DEBUG: Plugin Virtualbox: Could not execute "VBoxControl guestproperty enumerate". Skipping data
==> default: [2017-04-13T06:29:15+00:00] DEBUG: Plugin Hostname: ran 'hostname -s' and returned 0
==> default: [2017-04-13T06:29:15+00:00] DEBUG: Plugin Hostname: ran 'hostname' and returned 0
==> default: [2017-04-13T06:29:15+00:00] DEBUG: Plugin Hostname: ran 'hostname --fqdn' and returned 0
```  

As we don't need the additional ohai info, let's disable it!