### PR TITLE
Add --provision-only flag to update-vm.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Improvements:
     * force colored output when provisioning the VM without a tty
     * adjust chef-zero log level when provisioning the VM without a tty
  * noticeably improve chef-zero startup time by disabling the vmware ohai plugin (see [PR #40](https://github.com/tknerr/linus-kitchen/pull/40))
+ * add `--provision-only` flag to the `update-vm.sh` script (see [PR #42](https://github.com/tknerr/linus-kitchen/pull/42))
 
 ## 0.1 (May 11, 2016)
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ The update is done via Chef so it should be fully idempotent.
 
 You can run these commands from anywhere inside the VM:
 
- * `update-vm` - to apply the Chef recipes of the locally checked out linus-kitchen repo in `~/vm-setup`
- * `update-vm --pull` - same as above but update the repo before
- * `update-vm --verify-only` - don't update the VM, only run the Serverspec tests
+ * `update-vm` - to provision the VM (applies the Chef recipes from the local linus-kitchen repo at `~/vm-setup`)
+ * `update-vm --pull` - same as above, but pull the latest changes from the remote linus-kitchen repo before
+ * `update-vm --verify-only` - don't provision the VM, only run the Serverspec tests
+ * `update-vm --provision-only` - provision the VM, but don't run the Serverspec tests
 
 ## Acceptance Test
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,9 @@ Vagrant::configure("2") do |config|
   end
 
   # Install ChefDK and trigger the Chef run from within the VM
-  config.vm.provision "shell", privileged: false, keep_color: true, inline: "/vagrant/scripts/update-vm.sh"
+  config.vm.provision "shell", privileged: false, keep_color: true, run: 'always', inline: <<-EOF
+    /vagrant/scripts/update-vm.sh #{ENV['UPDATE_VM_FLAGS']}
+    EOF
   # Logout any existing GUI session to force the use to re-login, which is required
   # for group or keyboard layout changes to take effect
   config.vm.provision "shell", privileged: true, inline: "pkill -KILL -u vagrant; true"

--- a/circle.yml
+++ b/circle.yml
@@ -22,5 +22,6 @@ compile:
 test:
   override:
     - UPDATE_VM_FLAGS=--verify-only vagrant provision
+  post:
     - vagrant ssh -c 'cat ~/vm-setup/cookbooks/vm/test/junit-report.xml' > $CIRCLE_TEST_REPORTS/junit-report.xml
     - vagrant ssh -c 'cat ~/vm-setup/cookbooks/vm/test/test-report.html' > $CIRCLE_TEST_REPORTS/test-report.html

--- a/circle.yml
+++ b/circle.yml
@@ -13,8 +13,14 @@ dependencies:
     - wget https://releases.hashicorp.com/vagrant/1.9.3/vagrant_1.9.3_x86_64.deb
     - sudo dpkg -i vagrant_1.9.3_x86_64.deb
 
+compile:
+  pre:
+    - vagrant up --no-provision
+  override:
+    - UPDATE_VM_FLAGS=--provision-only vagrant provision
+
 test:
   override:
-    - vagrant up
+    - UPDATE_VM_FLAGS=--verify-only vagrant provision
     - vagrant ssh -c 'cat ~/vm-setup/cookbooks/vm/test/junit-report.xml' > $CIRCLE_TEST_REPORTS/junit-report.xml
     - vagrant ssh -c 'cat ~/vm-setup/cookbooks/vm/test/test-report.html' > $CIRCLE_TEST_REPORTS/test-report.html

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e -o pipefail
 
 CHEFDK_VERSION="1.3.32"
 TARGET_DIR="/tmp/vagrant-cache/wget"

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -122,5 +122,5 @@ else
   copy_repo_and_symlink_self
   [[ "$1" == "--pull" ]] && update_repo
   update_vm
-  verify_vm
+  [[ "$1" == "--provision-only" ]] || verify_vm
 fi


### PR DESCRIPTION
This PR adds a `--provision-only` flag to the `update-vm.sh` script, so that we can trigger these aspects individually:
 
 * vm creation
 * vm provisioning
 * vm testing

It also allows to pass these flags via vagrant using the `UPDATE_VM_FLAGS` env var. See the `circleci.yml` for a concrete usage