### PR TITLE
Install the vagrant-managed-servers Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Updated tools:
     * vagrant-omnibus to v1.5.0
     * vagrant-berkshelf to v5.1.1
     * vagrant-lxc to v1.2.3
+    * vagrant-managed-servers v0.8.0 (new plugin, see [PR #43](https://github.com/tknerr/linus-kitchen/pull/43))
  * update to Docker 1.13.1 (see [PR #34](https://github.com/tknerr/linus-kitchen/pull/34))
  * update to Atom Editor v1.15.0 and plugins (see [PR #35](https://github.com/tknerr/linus-kitchen/pull/35)):
     * atom-beautify to v0.29.18

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Other tweaks worth mentioning:
    * [vagrant-cachier](https://github.com/fgrehm/vagrant-cachier) - caches all kinds of packages you install in the vagrant VMs
    * [vagrant-berkshelf](https://github.com/berkshelf/vagrant-berkshelf) - berkshelf integration for vagrant
    * [vagrant-toplevel-cookbooks](https://github.com/tknerr/vagrant-toplevel-cookbooks) - support for one top-level cookbook per vagrant VM
+   * [vagrant-managed-servers](https://github.com/tknerr/vagrant-managed-servers) - Vagrant Provider for provisioning managed servers via SSH or WinRM
    * [vagrant-lxc](https://github.com/fgrehm/vagrant-lxc) - LXC provider for Vagrant
  * Pre-installed Atom plugins:
    * [atom-beautify](https://atom.io/packages/atom-beautify) - code formatter / beautifier for various languages

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -8,6 +8,7 @@ vagrant_plugins = {
   'vagrant-berkshelf' => '5.1.1',
   'vagrant-omnibus' => '1.5.0',
   'vagrant-toplevel-cookbooks' => '0.2.4',
+  'vagrant-managed-servers' => '0.8.0',
   'vagrant-lxc' => '1.2.3'
 }
 

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -32,6 +32,9 @@ describe 'vm::vagrant' do
     it 'installs "vagrant-toplevel-cookbooks" plugin v0.2.4' do
       expect(installed_plugins).to include 'vagrant-toplevel-cookbooks (0.2.4)'
     end
+    it 'installs "vagrant-managed-servers" plugin v0.8.0' do
+      expect(installed_plugins).to include 'vagrant-managed-servers (0.8.0)'
+    end
     it 'installs "vagrant-lxc" plugin v1.2.3' do
       expect(installed_plugins).to include 'vagrant-lxc (1.2.3)'
     end


### PR DESCRIPTION
This PR adds the [vagrant-managed-servers](https://github.com/tknerr/vagrant-managed-servers) provider, which can be used for provisioning servers where we only have access via SSH or WinRM, but have no control over the servers' lifecycle.

Use cases: deploy VMs hosted on ESX or somewhere else where:
 * you have no permissions to manage the lifecycle of the server or VM
 * you are working with a VM host where there is no suitable vagrant provider yet
 * you are deploying physical machines