### PR TITLE
Fix ChefDK download check in `update-vm.sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Improvements:
     * force colored output when provisioning the VM without a tty
     * adjust chef-zero log level when provisioning the VM without a tty
  * noticeably improve chef-zero startup time by disabling the vmware ohai plugin (see [PR #40](https://github.com/tknerr/linus-kitchen/pull/40))
- * add `--provision-only` flag to the `update-vm.sh` script (see [PR #42](https://github.com/tknerr/linus-kitchen/pull/42))
+ * add `--provision-only` flag to the `update-vm.sh` script (see [PR #42](https://github.com/tknerr/linus-kitchen/pull/42), [PR #47](https://github.com/tknerr/linus-kitchen/pull/47))
  * configure PS1 to provide a usable shell prompt for Git (see [PR #45](https://github.com/tknerr/linus-kitchen/pull/45))
 
 ## 0.1 (May 11, 2016)

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -34,9 +34,12 @@ check_chefdk() {
   else
     step "Downloading and installing ChefDK $CHEFDK_VERSION"
     mkdir -p $TARGET_DIR
-    wget --no-verbose --no-clobber -O $TARGET_DIR/chefdk_$CHEFDK_VERSION-1_amd64.deb \
-      https://packages.chef.io/files/current/chefdk/$CHEFDK_VERSION/ubuntu/16.04/chefdk_$CHEFDK_VERSION-1_amd64.deb
-    sudo dpkg -i $TARGET_DIR/chefdk_$CHEFDK_VERSION-1_amd64.deb
+    local CHEFDK_DEB=chefdk_$CHEFDK_VERSION-1_amd64.deb
+    local CHEFDK_URL=https://packages.chef.io/files/current/chefdk/$CHEFDK_VERSION/ubuntu/16.04/$CHEFDK_DEB
+    if [ ! -f $TARGET_DIR/$CHEFDK_DEB ]; then
+      wget -O $TARGET_DIR/$CHEFDK_DEB $CHEFDK_URL
+    fi
+    sudo dpkg -i $TARGET_DIR/$CHEFDK_DEB
   fi
 }
 

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -36,9 +36,7 @@ check_chefdk() {
     mkdir -p $TARGET_DIR
     local CHEFDK_DEB=chefdk_$CHEFDK_VERSION-1_amd64.deb
     local CHEFDK_URL=https://packages.chef.io/files/current/chefdk/$CHEFDK_VERSION/ubuntu/16.04/$CHEFDK_DEB
-    if [ ! -f $TARGET_DIR/$CHEFDK_DEB ]; then
-      wget -O $TARGET_DIR/$CHEFDK_DEB $CHEFDK_URL
-    fi
+    [[ -f $TARGET_DIR/$CHEFDK_DEB ]] || wget -O $TARGET_DIR/$CHEFDK_DEB $CHEFDK_URL
     sudo dpkg -i $TARGET_DIR/$CHEFDK_DEB
   fi
 }


### PR DESCRIPTION
As we added `set -e -o pipefail` somewhere in PR #42 it made subsequent runs of the `update-vm.sh` script fail.

Reason: `wget --no-clobber -O some/file` exits with a non-zero status code if the file already exists.

From the wget manual:

> A combination with ‘-O’/‘--output-document’ is only accepted if the given output file does not exist.

The general suggestion is to not use `--no-clobber` in combination with `-O`, but use timestamping via the `-N` option instead. 

This however did not work with chefdk (download server does not support it?), so I added a simple check if the file already exists. This is safe because the .deb name is unique for each version, and gives us the same behaviour we had with `--no-clobber` but with a 0 exit code.