### PR TITLE
Update Basebox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,8 @@
 Vagrant::configure("2") do |config|
 
   # configure the basebox
-  config.vm.box = "boxcutter/ubuntu1604-desktop"
+  config.vm.box = "tknerr/ubuntu1604-desktop"
+  config.vm.box_version = "2.0.27.1"
 
   # set the hostname
   config.vm.hostname = "linus-kitchen.local"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,7 @@ Vagrant::configure("2") do |config|
   # override the basebox when testing (an approximation) with docker
   config.vm.provider :docker do |docker, override|
     override.vm.box = "tknerr/baseimage-ubuntu-16.04"
+    override.vm.box_version = "1.0.0"
   end
 
   # Install ChefDK and trigger the Chef run from within the VM


### PR DESCRIPTION
This PR updates the basebox to Ubuntu Desktop 16.04.2 LTS with latest updates applied (as of April 17).

It is currently built from https://github.com/boxcutter/ubuntu/pull/110, and we should switch back to "boxcutter/ubuntu1604-desktop" as soon v2.0.27 with the above PR included is released