### PR TITLE
Don't overwrite the ~/.gitconfig on subsequent `update-vm` runs

### DIFF
--- a/cookbooks/vm/recipes/git.rb
+++ b/cookbooks/vm/recipes/git.rb
@@ -18,6 +18,7 @@ template "#{vm_user_home}/.gitconfig" do
   owner vm_user
   group vm_group
   mode '0644'
+  action :create_if_missing
 end
 
 bashd_entry 'setup-git-ps1-prompt' do


### PR DESCRIPTION
Usually the first thing a user does it setting his git username and email:
```
git config --global user.name "Your Name"
git config --global user.email "you@name.com"
```

Now the next time you run `update-vm` the username and email gets reset because the whole `~/.gitconfig` content is coming from a template.

This PR changes the behaviour so that the `~/.gitconfig` is initially provided, but will not be touched by chef again on subsequent runs.