### PR TITLE
update-vm.sh cleanup and optimizations + update to ChefDK 1.3.40 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Updated tools:
 
  * update to Ubuntu 16.04 basebox (see [PR #29](https://github.com/tknerr/linus-kitchen/pull/29))
- * update to ChefDK 1.3.32 (see [PR #32](https://github.com/tknerr/linus-kitchen/pull/32))
+ * update to ChefDK 1.3.40 (see [PR #32](https://github.com/tknerr/linus-kitchen/pull/32), [PR #55](https://github.com/tknerr/linus-kitchen/pull/55))
  * update Vagrant to v1.9.3 and plugins (see [PR #33](https://github.com/tknerr/linus-kitchen/pull/33), [PR #41](https://github.com/tknerr/linus-kitchen/pull/41)):
     * vagrant-omnibus to v1.5.0
     * vagrant-berkshelf to v5.1.1

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ should see all tests passing:
 ==> default:
 ==> default: update-vm.sh
 ==> default:   installs git
-==> default:   installs chefdk 1.3.32
+==> default:   installs chefdk 1.3.40
 ==> default:
 ==> default: Finished in 26.85 seconds (files took 1.08 seconds to load)
 ==> default: 48 examples, 0 failures

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You need [VMware Workstation Pro](https://www.vmware.com/products/workstation.ht
 
 If you don't mind about running 64-bit VirtualBox VMs inside Linus Kitchen, you only even need [VirtualBox](http://virtualbox.org/wiki/Downloads) and [Vagrant](http://www.vagrantup.com/) installed (note that VirtualBox only supports nested 32-bit guests).
 
-All other requirements, along with ChefDK and Git will be installed *inside the Vagrant VM* during provisioning, i.e. you don't need them installed on your host machine.
+All other requirements, including ChefDK will be installed *inside the Vagrant VM* during provisioning, i.e. you don't need them installed on your host machine.
 
 ### Basic Development Workflow
 
@@ -110,7 +110,7 @@ $ vagrant up
 This will take a while, as it will do quite a few things inside the VM:
 
  1. Setup a new user account ('user') under which the VM will be provisioned
- 1. Download and install [Git](https://git-scm.org/) and [ChefDK](https://downloads.chef.io/chef-dk/)
+ 1. Download and install [ChefDK](https://downloads.chef.io/chef-dk/)
  1. Copy the current directory into the VM (will be placed in `~/vm-setup`)
  1. Install cookbook dependencies via [Berkshelf](http://berkshelf.com/) to `~/vm-setup/cookbooks/vm/cookbooks`
  1. Trigger a [Chef-Zero](https://www.chef.io/blog/2013/10/31/chef-client-z-from-zero-to-chef-in-8-5-seconds/) run to apply the `~/vm-setup/cookbooks/vm/recipes` to the VM (see "What's included?")
@@ -123,8 +123,8 @@ should see all tests passing:
 ...
 ==> default:
 ==> default: update-vm.sh
-==> default:   installs git
 ==> default:   installs chefdk 1.3.40
+==> default:   symlinks the update-vm script to /usr/local/bin/
 ==> default:
 ==> default: Finished in 26.85 seconds (files took 1.08 seconds to load)
 ==> default: 48 examples, 0 failures
@@ -193,7 +193,7 @@ For VMware:
 ```
 $ vagrant halt
 $ VMX_FILE=`cat .vagrant/machines/default/vmware_fusion/id`
-$ ovftool --name="Linus Kitchen v0.1.0" "VMX_FILE" linus-kitchen-v0.1.0_vmware.ova
+$ ovftool --name="Linus Kitchen v0.1.0" "$VMX_FILE" linus-kitchen-v0.1.0_vmware.ova
 ```
 
 Don't forget to throw away the VM when you are done:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,8 @@ Vagrant::configure("2") do |config|
   # Ensure we cache as much as possible
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.enable :generic, {
-      "chef_file_cache" => { cache_dir: "/root/.chef/local-mode-cache/cache" }
+      "chef_file_cache" => { cache_dir: "/root/.chef/local-mode-cache/cache" },
+      "berkshelf_cache" => { cache_dir: "/home/vagrant/.berkshelf" }
     }
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,8 @@ Vagrant::configure("2") do |config|
 
   # set the hostname
   config.vm.hostname = "linus-kitchen.local"
+  # don't create a new keypair
+  config.ssh.insert_key = false
 
   # virtualbox specific customizations
   config.vm.provider :virtualbox do |vbox, override|

--- a/cookbooks/vm/metadata.rb
+++ b/cookbooks/vm/metadata.rb
@@ -8,6 +8,8 @@ version '0.2.0'
 issues_url 'https://github.com/tknerr/linus-kitchen/issues'
 source_url 'https://github.com/tknerr/linus-kitchen'
 
+chef_version '~> 12'
+
 supports 'ubuntu'
 
 depends 'apt', '6.0.1'

--- a/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
+++ b/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe 'update-vm.sh' do
 
-  it 'installs chefdk 1.3.32' do
-    expect(file('/opt/chefdk/version-manifest.txt')).to contain 'chefdk 1.3.32'
+  it 'installs chefdk 1.3.40' do
+    expect(file('/opt/chefdk/version-manifest.txt')).to contain 'chefdk 1.3.40'
   end
 
   it 'symlinks the update-vm script to /usr/local/bin/' do

--- a/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
+++ b/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
@@ -1,15 +1,12 @@
 require 'spec_helper'
 
 describe 'update-vm.sh' do
-  # Serverspec examples can be found at
-  # http://serverspec.org/resource_types.html
-
-  it 'installs git' do
-    expect(package('git')).to be_installed
-    expect(command('git --version').exit_status).to eq 0
-  end
 
   it 'installs chefdk 1.3.32' do
-    expect(command('chef --version').stdout).to contain 'Chef Development Kit Version: 1.3.32'
+    expect(file('/opt/chefdk/version-manifest.txt')).to contain 'chefdk 1.3.32'
+  end
+
+  it 'symlinks the update-vm script to /usr/local/bin/' do
+    expect(file('/usr/local/bin/update-vm')).to be_linked_to '/home/vagrant/vm-setup/scripts/update-vm.sh'
   end
 end

--- a/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
+++ b/cookbooks/vm/spec/integration/scripts/update_vm_spec.rb
@@ -7,6 +7,6 @@ describe 'update-vm.sh' do
   end
 
   it 'symlinks the update-vm script to /usr/local/bin/' do
-    expect(file('/usr/local/bin/update-vm')).to be_linked_to '/home/vagrant/vm-setup/scripts/update-vm.sh'
+    expect(file('/usr/local/bin/update-vm')).to be_linked_to "#{vm_user_home}/vm-setup/scripts/update-vm.sh"
   end
 end

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -2,68 +2,74 @@
 set -e -o pipefail
 
 CHEFDK_VERSION=1.3.32
-TARGET_DIR=/tmp/vagrant-cache/wget
+DOWNLOAD_DIR=/tmp/vagrant-cache/wget
 REPO_ROOT=~/vm-setup
+CMD_LINE_FLAG=$1
 
-big_step() {
-  echo ""
-  echo "====================================="
-  echo ">>>>>> $1"
-  echo "====================================="
-  echo ""
+main() {
+  setup_chefdk
+  if [[ "$CMD_LINE_FLAG" == "--verify-only" ]]; then
+    verify_vm
+  else
+    copy_repo_and_symlink_self
+    [[ "$CMD_LINE_FLAG" == "--pull" ]] && update_repo
+    update_vm
+    [[ "$CMD_LINE_FLAG" == "--provision-only" ]] || verify_vm
+  fi
 }
 
-step() {
-  echo ""
-  echo ""
-  echo ">>>>>> $1"
-  echo "-------------------------------------"
-  echo ""
-}
-
-check_chefdk() {
-  big_step "Checking ChefDK..."
-  if [[ $(chef -v | grep $CHEFDK_VERSION) ]]; then
+setup_chefdk() {
+  big_step "Setting up ChefDK..."
+  if [[ $(head -n1 /opt/chefdk/version-manifest.txt 2>/dev/null | grep "chefdk $CHEFDK_VERSION") ]]; then
     echo "ChefDK $CHEFDK_VERSION already installed"
   else
     step "Downloading and installing ChefDK $CHEFDK_VERSION"
-    mkdir -p $TARGET_DIR
+    mkdir -p $DOWNLOAD_DIR
     local CHEFDK_DEB=chefdk_$CHEFDK_VERSION-1_amd64.deb
     local CHEFDK_URL=https://packages.chef.io/files/current/chefdk/$CHEFDK_VERSION/ubuntu/16.04/$CHEFDK_DEB
-    [[ -f $TARGET_DIR/$CHEFDK_DEB ]] || wget -O $TARGET_DIR/$CHEFDK_DEB $CHEFDK_URL
-    sudo dpkg -i $TARGET_DIR/$CHEFDK_DEB
+    [[ -f $DOWNLOAD_DIR/$CHEFDK_DEB ]] || wget --no-verbose -O $DOWNLOAD_DIR/$CHEFDK_DEB $CHEFDK_URL
+    sudo dpkg -i $DOWNLOAD_DIR/$CHEFDK_DEB
   fi
-}
-
-check_git() {
-  big_step "Checking Git..."
-  if [[ $(which git) ]]; then
-    echo "Git already installed"
-  else
-    step "Installing Git"
-    sudo apt-get update
-    sudo apt-get install git -y
-  fi
+  # initialize the shell, adding ChefDK binaries to the PATH
+  eval "$(chef shell-init bash)"
 }
 
 copy_repo_and_symlink_self() {
   big_step "Copying repo into the VM..."
   if mountpoint -q /vagrant; then
-    step "Copy /vagrant to $REPO_ROOT"
     sudo rm -rf $REPO_ROOT
     sudo cp -r /vagrant $REPO_ROOT
     sudo chown -R $USER:$USER $REPO_ROOT
-    step "Symlinking 'update-vm' script"
     sudo ln -sf $REPO_ROOT/scripts/update-vm.sh /usr/local/bin/update-vm
+    echo "Copied repo to $REPO_ROOT and symlinked the 'update-vm' script"
   else
     echo "Skipped because /vagrant not mounted"
   fi
 }
 
-shell_init() {
-  step "init the shell"
-  set -e
-  eval "$(chef shell-init bash)"
+update_vm() {
+  big_step "Updating the VM via Chef..."
+  cd $REPO_ROOT/cookbooks/vm
+
+  step "install cookbook dependencies"
+  berks vendor --delete ./cookbooks
+
+  # disable vmware ohai plugin because it's so painfully slow
+  sudo find /opt/chefdk/embedded/ -wholename *ohai* -name vmware.rb -exec mv {} {}.disabled \;
+
+  step "update the system via chef-zero"
+  sudo -H chef-client --config-option node_path=/root/.chef/nodes --local-mode --format=doc --force-formatter --log_level=warn --color --runlist=vm
+}
+
+verify_vm() {
+  big_step "Verifying the VM..."
+  cd $REPO_ROOT/cookbooks/vm
+
+  step "run foodcritic linting checks"
+  foodcritic -f any .
+
+  step "run serverspec integration tests"
+  rspec --require rspec_junit_formatter --format doc --color --tty --format RspecJunitFormatter --out test/junit-report.xml --format html --out test/test-report.html
 }
 
 update_repo() {
@@ -72,50 +78,12 @@ update_repo() {
   git pull
 }
 
-update_vm() {
-  big_step "Updating the VM via Chef..."
-
-  shell_init
-  cd $REPO_ROOT/cookbooks/vm
-
-  # install cookbook dependencies
-  step "install cookbook dependencies"
-  rm -rf ./cookbooks
-  berks vendor ./cookbooks
-
-  # disable vmware ohai plugin because it's so painfully slow
-  sudo find /opt/chefdk/embedded/ -wholename *ohai* -name vmware.rb -exec mv {} {}.disabled \;
-
-  # converge the system via chef-zero
-  step "trigger the chef-zero run"
-  sudo -H chef-client --config-option node_path=/root/.chef/nodes --local-mode --format=doc --force-formatter --log_level=warn --color --runlist=vm
+big_step() {
+  echo -e "\n=====================================\n>>>>>> $1\n=====================================\n"
+}
+step() {
+  echo -e "\n\n>>>>>> $1\n-------------------------------------\n"
 }
 
-verify_vm() {
-  big_step "Verifying the VM..."
-
-  shell_init
-  cd $REPO_ROOT/cookbooks/vm
-
-  # run lint checks
-  step "run codestyle checks"
-  foodcritic -f any .
-
-  # run integration tests
-  step "run integration tests"
-  rspec --require rspec_junit_formatter --format doc --color --tty --format RspecJunitFormatter --out test/junit-report.xml --format html --out test/test-report.html
-}
-
-#
-# main flow
-#
-if [[ "$1" == "--verify-only" ]]; then
-  verify_vm
-else
-  check_git
-  check_chefdk
-  copy_repo_and_symlink_self
-  [[ "$1" == "--pull" ]] && update_repo
-  update_vm
-  [[ "$1" == "--provision-only" ]] || verify_vm
-fi
+# run it!
+main

--- a/scripts/update-vm.sh
+++ b/scripts/update-vm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 
-CHEFDK_VERSION=1.3.32
+CHEFDK_VERSION=1.3.40
 DOWNLOAD_DIR=/tmp/vagrant-cache/wget
 REPO_ROOT=~/vm-setup
 CMD_LINE_FLAG=$1
@@ -26,8 +26,8 @@ setup_chefdk() {
     step "Downloading and installing ChefDK $CHEFDK_VERSION"
     mkdir -p $DOWNLOAD_DIR
     local CHEFDK_DEB=chefdk_$CHEFDK_VERSION-1_amd64.deb
-    local CHEFDK_URL=https://packages.chef.io/files/current/chefdk/$CHEFDK_VERSION/ubuntu/16.04/$CHEFDK_DEB
-    [[ -f $DOWNLOAD_DIR/$CHEFDK_DEB ]] || wget --no-verbose -O $DOWNLOAD_DIR/$CHEFDK_DEB $CHEFDK_URL
+    local CHEFDK_URL=https://packages.chef.io/files/stable/chefdk/$CHEFDK_VERSION/ubuntu/16.04/$CHEFDK_DEB
+    [[ -f $DOWNLOAD_DIR/$CHEFDK_DEB ]] || sudo wget --no-verbose -O $DOWNLOAD_DIR/$CHEFDK_DEB $CHEFDK_URL
     sudo dpkg -i $DOWNLOAD_DIR/$CHEFDK_DEB
   fi
   # initialize the shell, adding ChefDK binaries to the PATH


### PR DESCRIPTION
This PR adds the follwing improvements from Zuehlke/linux-developer-vm#17 to make the provisioning process faster:

 * faster chefdk version check (both in `update-vm.sh` and tests)
 * add cache for berkshelf resolved cookbook dependencies
 * don't create a new keypair on vagrant up -- use the default insecure one (we anyway remove the vagrant account before packaging)
 * don't install Git in `update-vm.sh` (use the ChefDK provided one instead)

It also updates ChefDK to 1.3.40 from the "stable" channel, because 1.3.32 was only in the "current" channel and got removed in the meantime