### PR TITLE
Place a README on the desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Improvements:
  * restructure the README to better differentiate between Usage and Development (see [PR #50](https://github.com/tknerr/linus-kitchen/pull/50))
  * added a `LICENSE` file to provide the sources under MIT license (see [PR #51](https://github.com/tknerr/linus-kitchen/pull/51))
  * cleanup: renove outdated workarounds, TODOs and rubocop linting (see [PR #54](https://github.com/tknerr/linus-kitchen/pull/54))
+ * place a README on the Desktop for better guiding the user (see [PR #56](https://github.com/tknerr/linus-kitchen/pull/56))
 
 Breaking changes:
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Other tweaks worth mentioning:
    * [atom-beautify](https://atom.io/packages/atom-beautify) - code formatter / beautifier for various languages
    * [minimap](https://atom.io/packages/minimap) - a SublimeText like minimap
    * [language-chef](https://atom.io/packages/language-chef) - code snippets for Chef recipes
+ * Placed a `README.md` file on the Desktop to guide first time users after they logged in to the VM
  * Symlinked [`update-vm.sh`](scripts/update-vm.sh) to `/usr/local/bin/update-vm` so it's in the `$PATH` and can be used for updating the VM from the inside (see below)
 
 

--- a/cookbooks/vm/files/default/desktop_readme.md
+++ b/cookbooks/vm/files/default/desktop_readme.md
@@ -1,0 +1,48 @@
+
+# README
+
+A brief guide to walk you through the initial setup of this developer VM
+
+## Initial Keyboard Setup
+
+Configure the keyboard layout and adjust the timezone:
+
+ * System Settings... -> Text Entry
+ * System Settings... -> Time & Date
+
+If you have a totally different keymap (e.g. on a MacBook) you can always reconfigure it:
+```
+sudo dpkg-reconfigure keyboard-configuration
+```
+
+## Updating this Developer VM
+
+You can run these commands from anywhere inside this developer VM:
+
+ * `update-vm` - update the VM by applying the Chef recipes from the locally checked out repo at `~/vm-setup`
+ * `update-vm --pull` - same as above, but update repo before by pulling the latest changes
+ * `update-vm --verify-only` - don't update the VM, only run the Serverspec tests
+ * `update-vm --provision-only` - don't run the Serverspec tests, only update the vm
+
+
+## Getting Started!
+
+Please refer to the sections below on how to start developing with the specific toolchain in this developer VM.
+
+### Initial Git Configuration
+
+Generate a new SSH keypair (and add the public key [to your Github account](https://github.com/settings/keys)):
+```
+ssh-keygen -t rsa -b 4096 -C "your.name@linus-kitchen"
+```
+
+Configure your git username / email:
+```
+git config --global user.name "Your Name"
+git config --global user.email "your.name@isp.com"
+```
+
+### Follow the ZDays 2015 Tutorials
+
+Now that you are all set up, you can follow the Chef / Vagrant tutorials in here:
+https://github.com/tknerr/zdays2015-demo-repo

--- a/cookbooks/vm/recipes/base.rb
+++ b/cookbooks/vm/recipes/base.rb
@@ -2,6 +2,20 @@
 include_recipe 'apt'
 include_recipe 'chef-sugar'
 
-%w(vim git libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb indicator-multiload).each do |pkg|
+# commonly needed packages / tools
+%w(vim libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb indicator-multiload).each do |pkg|
   package pkg
+end
+
+# place a README on the Desktop
+directory "#{vm_user_home}/Desktop" do
+  owner vm_user
+  group vm_user
+  mode '0755'
+end
+cookbook_file "#{vm_user_home}/Desktop/README.md" do
+  source "desktop_readme.md"
+  owner vm_user
+  group vm_user
+  mode '0644'
 end

--- a/cookbooks/vm/spec/integration/recipes/base_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/base_spec.rb
@@ -19,4 +19,8 @@ describe 'vm::base' do
     expect(package('indicator-multiload')).to be_installed
   end
 
+  it 'places a README on the Desktop' do
+    expect(file("#{vm_user_home}/Desktop/README.md")).to exist
+  end
+
 end


### PR DESCRIPTION
Following the template in https://github.com/Zuehlke/linux-developer-vm/pull/18 we also add a README.md to the desktop.

Instructions included:

 * how to configure the keyboard / timezone
 * how to update the VM
 * how to configure your Git client
 * how to get started with Chef / Vagrant