### PR TITLE
Update to Atom v1.17.1 (+ Plugins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Updated tools:
  * update to VirtualBox v5.1.22 (see [PR #59](https://github.com/tknerr/linus-kitchen/pull/59))
  * update to Docker v17.05.0-ce (see [PR #61](https://github.com/tknerr/linus-kitchen/pull/61))
  * update to ChefDK v1.4.3 (see [PR #62](https://github.com/tknerr/linus-kitchen/pull/62))
- * update to Atom Editor v1.18.0-beta1 and plugins (see [PR #60](https://github.com/tknerr/linus-kitchen/pull/60)):
+ * update to Atom Editor v1.17.1 and plugins (see [PR #60](https://github.com/tknerr/linus-kitchen/pull/60)):
     * atom-beautify to v0.29.24
     * atom-minimap to v4.28.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Updated tools:
  * update to VirtualBox v5.1.22 (see [PR #59](https://github.com/tknerr/linus-kitchen/pull/59))
  * update to Docker v17.05.0-ce (see [PR #61](https://github.com/tknerr/linus-kitchen/pull/61))
  * update to ChefDK v1.4.3 (see [PR #62](https://github.com/tknerr/linus-kitchen/pull/62))
+ * update to Atom Editor v1.18.0-beta1 and plugins (see [PR #60](https://github.com/tknerr/linus-kitchen/pull/60)):
+    * atom-beautify to v0.29.24
+    * atom-minimap to v4.28.2
 
 ## 0.2 (May 12, 2017)
 

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -1,5 +1,5 @@
 
-atom_version = '1.18.0-beta1'
+atom_version = '1.17.1'
 atom_deb_file = "atom-v#{atom_version}-amd64.deb"
 
 atom_plugins = {

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -1,5 +1,5 @@
 
-atom_version = '1.15.0'
+atom_version = '1.18.0-beta1'
 atom_deb_file = "atom-v#{atom_version}-amd64.deb"
 
 atom_plugins = {

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -3,8 +3,8 @@ atom_version = '1.18.0-beta1'
 atom_deb_file = "atom-v#{atom_version}-amd64.deb"
 
 atom_plugins = {
-  'atom-beautify' => '0.29.18',
-  'minimap' => '4.27.1',
+  'atom-beautify' => '0.29.24',
+  'minimap' => '4.28.2',
   'language-chef' => '0.9.0'
 }
 

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -8,11 +8,9 @@ atom_plugins = {
   'language-chef' => '0.9.0'
 }
 
+# ensure we have the required gui packages for starting atom in docker / Circle CI
 if docker?
-  # we need libxss-dev for starting atom in docker
-  package 'libxss-dev'
-  # avoid /dev/fuse issues on circleci
-  extra_options = '--no-install-recommends'
+  package ['libxss-dev', 'gconf2', 'libgtk2.0-0', 'libnotify4', 'gvfs-bin', 'xdg-utils']
 end
 
 # install atom editor

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -20,12 +20,9 @@ remote_file "#{Chef::Config[:file_cache_path]}/#{atom_deb_file}" do
   source "https://github.com/atom/atom/releases/download/v#{atom_version}/atom-amd64.deb"
   mode '0644'
 end
-bash 'install-atom-with-dependencies' do
-  code <<-EOF
-    dpkg -i #{Chef::Config[:file_cache_path]}/#{atom_deb_file}
-    apt-get -y --fix-broken install #{extra_options}
-    EOF
-  not_if "which atom && xvfb-run atom -v | grep -q '#{atom_version}'"
+dpkg_package 'atom' do
+  source "#{Chef::Config[:file_cache_path]}/#{atom_deb_file}"
+  version atom_version
 end
 
 # install atom plugins

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -6,8 +6,8 @@ describe 'vm::atom' do
   let(:atom_config) { file("#{vm_user_home}/.atom/config.cson") }
   let(:installed_plugins) { vm_user_command('apm list -i -b').stdout }
 
-  it 'installs atom 1.15.0' do
-    expect(atom_version).to contain '1.15.0'
+  it 'installs atom 1.18.0-beta1' do
+    expect(atom_version).to contain '1.18.0-beta1'
   end
 
   describe 'plugins' do

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -6,8 +6,8 @@ describe 'vm::atom' do
   let(:atom_config) { file("#{vm_user_home}/.atom/config.cson") }
   let(:installed_plugins) { vm_user_command('apm list -i -b').stdout }
 
-  it 'installs atom 1.18.0-beta1' do
-    expect(atom_version).to contain '1.18.0-beta1'
+  it 'installs atom 1.17.1' do
+    expect(atom_version).to contain '1.17.1'
   end
 
   describe 'plugins' do

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -11,11 +11,11 @@ describe 'vm::atom' do
   end
 
   describe 'plugins' do
-    it 'installs "atom-beautify" plugin v0.29.18' do
-      expect(installed_plugins).to contain 'atom-beautify@0.29.18'
+    it 'installs "atom-beautify" plugin v0.29.24' do
+      expect(installed_plugins).to contain 'atom-beautify@0.29.24'
     end
-    it 'installs "minimap" plugin v4.27.1' do
-      expect(installed_plugins).to contain 'minimap@4.27.1'
+    it 'installs "minimap" plugin v4.28.2' do
+      expect(installed_plugins).to contain 'minimap@4.28.2'
     end
     it 'installs "language-chef" plugin v0.9.0' do
       expect(installed_plugins).to contain 'language-chef@0.9.0'


### PR DESCRIPTION
Updates to Atom Editor v1.17.1 and the following plugins:

 * atom-beautify to v0.29.24
 * atom-minimap to v4.28.2

Also removes the workaround for installing the .deb package dependencies via `execute` resource. We now use the `dpkg_package` resource and install the missing dependencies only in the docker / CircleCI build, as they are missing only there (because: the docker basebox is ubuntu server, not desktop)