### PR TITLE
Add ansible, testinfra and molecule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Updated tools:
  * update to Atom Editor v1.17.1 and plugins (see [PR #60](https://github.com/tknerr/linus-kitchen/pull/60)):
     * atom-beautify to v0.29.24
     * atom-minimap to v4.28.2
+    * language-ansible to v0.2.1 (new)
 
 Newly installed tools:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Updated tools:
     * atom-beautify to v0.29.24
     * atom-minimap to v4.28.2
 
+Newly installed tools:
+
+ * installed a toolchain for developing with [Ansible](https://www.ansible.com/) (see [PR #63](https://github.com/tknerr/linus-kitchen/pull/63)), including:
+    * ansible v2.3.0.0
+    * molecule v2.0.0.rc5
+    * testinfra v1.6.2
+    * ansible-lint v3.4.12
+
 ## 0.2 (May 12, 2017)
 
 Updated tools:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Circle CI](https://circleci.com/gh/tknerr/linus-kitchen/tree/master.svg?style=shield)](https://circleci.com/gh/tknerr/linus-kitchen/tree/master)
 
-An Ubuntu Desktop 16.04 based development box for Infrastructure-as-Code development with Vagrant, Chef & Co.
+An Ubuntu Desktop 16.04 based development box for Infrastructure-as-Code development with Vagrant, Chef, Ansible & Co.
 
 ![Linus' Kitchen Screenshot](https://raw.github.com/tknerr/linus-kitchen/master/linus_kitchen.png)
 
@@ -19,11 +19,31 @@ These are the main tools included in Linus' Kitchen (see CHANGELOG for the speci
 
  * [Git](https://git-scm.org/)
  * [ChefDK](https://downloads.chef.io/chef-dk/)
+ * [Ansible](https://www.ansible.com/)
  * [Vagrant](http://vagrantup.com/)
  * [Packer](http://packer.io/)
  * [VirtualBox](https://www.virtualbox.org/)
  * [Docker](http://docker.io/)
  * [Atom Editor](http://atom.io/)
+
+#### Chef-based development toolchain
+
+In addition to Chef itself, the following tools (which are all Ruby-based) come included with ChefDK:
+
+ * [berkshelf](https://berkshelf.com/) - a dependency manager for Chef cookbooks
+ * [foodcritic](http://www.foodcritic.io/) - a lint tool for Chef cookbooks
+ * [chefspec](https://chefspec.github.io/chefspec/) - unit testing for Chef cookbooks
+ * [serverspec](http://serverspec.org/) - rspec based framework for testing servers
+ * [test-kitchen](http://kitchen.ci/) - a test driver for orchestrating and testing infrastructure
+
+#### Ansible-based development toolchain
+
+In addition to Ansible itself, the following tools (which are all Python-based) are included:
+
+ * [ansible-galaxy](https://docs.ansible.com/ansible/galaxy.html) - a dependency manager for Ansible roles
+ * [ansible-lint](https://github.com/willthames/ansible-lint) - a lint tool for Ansible roles
+ * [testinfra](https://testinfra.readthedocs.io/) - a pytest based framework for testing servers
+ * [molecule](https://molecule.readthedocs.io/) - a test driver for orchestrating and testing infrastructure
 
 ### Tweaks and Plugins
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Other tweaks worth mentioning:
    * [atom-beautify](https://atom.io/packages/atom-beautify) - code formatter / beautifier for various languages
    * [minimap](https://atom.io/packages/minimap) - a SublimeText like minimap
    * [language-chef](https://atom.io/packages/language-chef) - code snippets for Chef recipes
+   * [language-ansible](https://atom.io/packages/language-ansible) - code snippets for Ansible roles
  * Placed a `README.md` file on the Desktop to guide first time users after they logged in to the VM
  * Symlinked [`update-vm.sh`](scripts/update-vm.sh) to `/usr/local/bin/update-vm` so it's in the `$PATH` and can be used for updating the VM from the inside (see below)
 

--- a/cookbooks/vm/libraries/helpers.rb
+++ b/cookbooks/vm/libraries/helpers.rb
@@ -60,5 +60,15 @@ class Chef
                environment: vm_user_env
       end
     end
+
+    #
+    # install a (system wide) pip package
+    #
+    def install_pip_package(name, version)
+      bash "install pip package #{name}-#{version} for #{vm_user}" do
+        code "pip install #{name}==#{version}"
+        not_if "pip freeze | grep -q '#{name}==#{version}'"
+      end
+    end
   end
 end

--- a/cookbooks/vm/recipes/ansible.rb
+++ b/cookbooks/vm/recipes/ansible.rb
@@ -6,6 +6,7 @@ package ['python-pip', 'libssl-dev', 'libffi-dev']
 install_pip_package 'ansible', '2.3.0.0'
 
 # install testinfra with the spec formatter, and molecule
+install_pip_package 'ansible-lint', '3.4.12'
 install_pip_package 'testinfra', '1.6.2'
 install_pip_package 'pytest-spec', '1.1.0'
 install_pip_package 'molecule', '2.0.0.0rc5'

--- a/cookbooks/vm/recipes/ansible.rb
+++ b/cookbooks/vm/recipes/ansible.rb
@@ -8,4 +8,4 @@ install_pip_package 'ansible', '2.3.0.0'
 # install testinfra with the spec formatter, and molecule
 install_pip_package 'testinfra', '1.6.2'
 install_pip_package 'pytest-spec', '1.1.0'
-install_pip_package 'molecule', '2.0.0.0rc4'
+install_pip_package 'molecule', '2.0.0.0rc5'

--- a/cookbooks/vm/recipes/ansible.rb
+++ b/cookbooks/vm/recipes/ansible.rb
@@ -1,0 +1,11 @@
+
+# install required dependencies
+package ['python-pip', 'libssl-dev', 'libffi-dev']
+
+# install ansible
+install_pip_package 'ansible', '2.3.0.0'
+
+# install testinfra with the spec formatter, and molecule
+install_pip_package 'testinfra', '1.6.2'
+install_pip_package 'pytest-spec', '1.1.0'
+install_pip_package 'molecule', '2.0.0.0rc4'

--- a/cookbooks/vm/recipes/atom.rb
+++ b/cookbooks/vm/recipes/atom.rb
@@ -5,7 +5,8 @@ atom_deb_file = "atom-v#{atom_version}-amd64.deb"
 atom_plugins = {
   'atom-beautify' => '0.29.24',
   'minimap' => '4.28.2',
-  'language-chef' => '0.9.0'
+  'language-chef' => '0.9.0',
+  'language-ansible' => '0.2.1'
 }
 
 # ensure we have the required gui packages for starting atom in docker / Circle CI

--- a/cookbooks/vm/recipes/default.rb
+++ b/cookbooks/vm/recipes/default.rb
@@ -2,6 +2,7 @@
 include_recipe 'vm::base'
 include_recipe 'vm::bash'
 include_recipe 'vm::git'
+include_recipe 'vm::ansible'
 include_recipe 'vm::chefdk'
 include_recipe 'vm::virtualbox'
 include_recipe 'vm::vagrant'

--- a/cookbooks/vm/spec/integration/recipes/ansible_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/ansible_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'vm::ansible' do
+
+  let(:ansible_version) { vm_user_gui_command('ansible --version').stdout }
+  let(:testinfra_version) { vm_user_gui_command('testinfra --version').stdout }
+  let(:molecule_version) { vm_user_gui_command('molecule --version').stdout }
+
+  it 'installs ansible 2.3.0.0' do
+    expect(ansible_version).to contain '2.3.0.0'
+  end
+  it 'installs testinfra 1.6.2' do
+    expect(testinfra_version).to contain '1.6.2'
+  end
+  it 'installs molecule 2.0.0.0rc4' do
+    expect(molecule_version).to contain '2.0.0.0rc4'
+  end
+end

--- a/cookbooks/vm/spec/integration/recipes/ansible_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/ansible_spec.rb
@@ -3,11 +3,15 @@ require 'spec_helper'
 describe 'vm::ansible' do
 
   let(:ansible_version) { vm_user_gui_command('ansible --version').stdout }
+  let(:ansible_lint_version) { vm_user_gui_command('ansible-lint --version').stdout }
   let(:pytest_version) { vm_user_gui_command('pytest --version').stdout }
   let(:molecule_version) { vm_user_gui_command('molecule --version').stdout }
 
   it 'installs ansible 2.3.0.0' do
     expect(ansible_version).to contain '2.3.0.0'
+  end
+  it 'installs ansible-lint 3.4.12' do
+    expect(ansible_lint_version).to contain '3.4.12'
   end
   it 'installs testinfra 1.6.2' do
     expect(pytest_version).to contain 'testinfra-1.6.2'

--- a/cookbooks/vm/spec/integration/recipes/ansible_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/ansible_spec.rb
@@ -3,14 +3,17 @@ require 'spec_helper'
 describe 'vm::ansible' do
 
   let(:ansible_version) { vm_user_gui_command('ansible --version').stdout }
-  let(:testinfra_version) { vm_user_gui_command('testinfra --version').stdout }
+  let(:pytest_version) { vm_user_gui_command('pytest --version').stdout }
   let(:molecule_version) { vm_user_gui_command('molecule --version').stdout }
 
   it 'installs ansible 2.3.0.0' do
     expect(ansible_version).to contain '2.3.0.0'
   end
   it 'installs testinfra 1.6.2' do
-    expect(testinfra_version).to contain '1.6.2'
+    expect(pytest_version).to contain 'testinfra-1.6.2'
+  end
+  it 'installs pytest-spec 1.1.0' do
+    expect(pytest_version).to contain 'pytest-spec-1.1.0'
   end
   it 'installs molecule 2.0.0.0rc4' do
     expect(molecule_version).to contain '2.0.0.0rc4'

--- a/cookbooks/vm/spec/integration/recipes/ansible_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/ansible_spec.rb
@@ -15,7 +15,7 @@ describe 'vm::ansible' do
   it 'installs pytest-spec 1.1.0' do
     expect(pytest_version).to contain 'pytest-spec-1.1.0'
   end
-  it 'installs molecule 2.0.0.0rc4' do
-    expect(molecule_version).to contain '2.0.0.0rc4'
+  it 'installs molecule 2.0.0.0rc5' do
+    expect(molecule_version).to contain '2.0.0.0rc5'
   end
 end

--- a/cookbooks/vm/spec/integration/recipes/atom_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/atom_spec.rb
@@ -20,6 +20,9 @@ describe 'vm::atom' do
     it 'installs "language-chef" plugin v0.9.0' do
       expect(installed_plugins).to contain 'language-chef@0.9.0'
     end
+    it 'installs "language-ansible" plugin v0.2.1' do
+      expect(installed_plugins).to contain 'language-ansible@0.2.1'
+    end
   end
 
   it 'configures atom to have sublime tabs behaviour' do


### PR DESCRIPTION
This PR adds an ansible toolchain with the following tools:

 * ansible 2.3.0.0 - the configuration management tool
 * testinfra 1.6.2 - a testing framework akin to serverspec
 * molecule 2.0.0.0rc5 - a test driver akin to test-kitchen