### PR TITLE
Remove outdated vagrant plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,8 @@ Other tweaks worth mentioning:
   * Bundler is configured for parallel downloading and retrying (see `~/.bundle/config`)
   * Customized `~/.vagrant.d/Vagrantfile` and `~/.kitchen/config.yml` for caching as much as possible
   * Pre-installed Vagrant plugins:
-  * [vagrant-omnibus](https://github.com/schisamo/vagrant-omnibus) - installs omnibus chef in a vagrant VM
     * [vagrant-cachier](https://github.com/fgrehm/vagrant-cachier) - caches all kinds of packages you install in the vagrant VMs
-    * [vagrant-berkshelf](https://github.com/berkshelf/vagrant-berkshelf) - berkshelf integration for vagrant
-    * [vagrant-toplevel-cookbooks](https://github.com/tknerr/vagrant-toplevel-cookbooks) - support for one top-level cookbook per vagrant VM
     * [vagrant-managed-servers](https://github.com/tknerr/vagrant-managed-servers) - Vagrant Provider for provisioning managed servers via SSH or WinRM
-    * [vagrant-lxc](https://github.com/fgrehm/vagrant-lxc) - LXC provider for Vagrant
   * Pre-installed Visual Studio Code plugins:
     * [bbenoist.vagrant](https://marketplace.visualstudio.com/items?itemName=bbenoist.vagrant) - allows you to control Vagrant boxes from within VSCode
     * [dhoeric.ansible-vault](https://marketplace.visualstudio.com/items?itemName=dhoeric.ansible-vault) - encrypt/decrypt Ansible vault credentials

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -8,8 +8,7 @@ vagrant_plugins = {
   'vagrant-berkshelf' => '5.1.2',
   'vagrant-omnibus' => '1.5.0',
   'vagrant-toplevel-cookbooks' => '0.2.4',
-  'vagrant-managed-servers' => '0.8.0',
-  'vagrant-lxc' => '1.4.3'
+  'vagrant-managed-servers' => '0.8.0'
 }
 
 # download and install vagrant
@@ -33,19 +32,6 @@ end
 bashrc_manager 'set-vagrant-default-provider' do
   user vm_user
   content "export VAGRANT_DEFAULT_PROVIDER=#{vmware? ? 'virtualbox' : 'docker'}"
-end
-
-#
-# vagrant-lxc setup
-#
-%w(lxc lxc-templates cgroup-lite redir bridge-utils).each do |pkg|
-  package pkg
-end
-
-bash 'add vagrant-lxc sudoers permissions' do
-  environment vm_user_env
-  code 'vagrant lxc sudoers'
-  not_if { ::File.exist? '/etc/sudoers.d/vagrant-lxc' }
 end
 
 #

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -5,7 +5,6 @@ vagrant_checksum = '1ffb66020b580492ebf9189af8a48c48cdb31825be0717d600518a881584
 
 vagrant_plugins = {
   'vagrant-cachier' => '1.2.1',
-  'vagrant-toplevel-cookbooks' => '0.2.4',
   'vagrant-managed-servers' => '0.8.0'
 }
 

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -6,7 +6,6 @@ vagrant_checksum = '1ffb66020b580492ebf9189af8a48c48cdb31825be0717d600518a881584
 vagrant_plugins = {
   'vagrant-cachier' => '1.2.1',
   'vagrant-berkshelf' => '5.1.2',
-  'vagrant-omnibus' => '1.5.0',
   'vagrant-toplevel-cookbooks' => '0.2.4',
   'vagrant-managed-servers' => '0.8.0'
 }

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -5,7 +5,6 @@ vagrant_checksum = '1ffb66020b580492ebf9189af8a48c48cdb31825be0717d600518a881584
 
 vagrant_plugins = {
   'vagrant-cachier' => '1.2.1',
-  'vagrant-berkshelf' => '5.1.2',
   'vagrant-toplevel-cookbooks' => '0.2.4',
   'vagrant-managed-servers' => '0.8.0'
 }

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -26,9 +26,6 @@ describe 'vm::vagrant' do
     it 'installs "vagrant-berkshelf" plugin v5.1.2' do
       expect(installed_plugins).to include 'vagrant-berkshelf (5.1.2, global)'
     end
-    it 'installs "vagrant-omnibus" plugin v1.5.0' do
-      expect(installed_plugins).to include 'vagrant-omnibus (1.5.0, global)'
-    end
     it 'installs "vagrant-toplevel-cookbooks" plugin v0.2.4' do
       expect(installed_plugins).to include 'vagrant-toplevel-cookbooks (0.2.4, global)'
     end

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -35,8 +35,5 @@ describe 'vm::vagrant' do
     it 'installs "vagrant-managed-servers" plugin v0.8.0' do
       expect(installed_plugins).to include 'vagrant-managed-servers (0.8.0, global)'
     end
-    it 'installs "vagrant-lxc" plugin v1.4.3' do
-      expect(installed_plugins).to include 'vagrant-lxc (1.4.3, global)'
-    end
   end
 end

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -23,9 +23,6 @@ describe 'vm::vagrant' do
     it 'installs "vagrant-cachier" plugin v1.2.1' do
       expect(installed_plugins).to include 'vagrant-cachier (1.2.1, global)'
     end
-    it 'installs "vagrant-toplevel-cookbooks" plugin v0.2.4' do
-      expect(installed_plugins).to include 'vagrant-toplevel-cookbooks (0.2.4, global)'
-    end
     it 'installs "vagrant-managed-servers" plugin v0.8.0' do
       expect(installed_plugins).to include 'vagrant-managed-servers (0.8.0, global)'
     end

--- a/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/vagrant_spec.rb
@@ -23,9 +23,6 @@ describe 'vm::vagrant' do
     it 'installs "vagrant-cachier" plugin v1.2.1' do
       expect(installed_plugins).to include 'vagrant-cachier (1.2.1, global)'
     end
-    it 'installs "vagrant-berkshelf" plugin v5.1.2' do
-      expect(installed_plugins).to include 'vagrant-berkshelf (5.1.2, global)'
-    end
     it 'installs "vagrant-toplevel-cookbooks" plugin v0.2.4' do
       expect(installed_plugins).to include 'vagrant-toplevel-cookbooks (0.2.4, global)'
     end


### PR DESCRIPTION
Removes outdated plugins, which have been retired or superseded:

 * vagrant-omnibus [is deprecated](https://github.com/chef-boneyard/vagrant-omnibus#deprecation-warning) and superseded by test-kitchen
 * vagrant-berkshelf has been [deprecated / archived](https://github.com/berkshelf/vagrant-berkshelf#vagrant-berkshelf-vs-test-kitchen) and is superseded by test-kitchen as well
 * [vagrant-toplevel-cookbooks](https://github.com/tknerr/vagrant-toplevel-cookbooks) is no longer actively maintained and never caught traction anyway 