### PR TITLE
Fix idempotence in subsequent Chef runs

### DIFF
--- a/cookbooks/vm/libraries/helpers.rb
+++ b/cookbooks/vm/libraries/helpers.rb
@@ -37,7 +37,7 @@ class Chef
         group vm_group
         environment vm_user_env
         code "vagrant plugin install #{name} --plugin-version #{version}"
-        not_if "vagrant plugin list | grep -q '#{name} (#{version})'",
+        not_if "vagrant plugin list | grep -q '#{name} (#{version}, global)'",
                user: vm_user,
                group: vm_group,
                environment: vm_user_env

--- a/cookbooks/vm/recipes/base.rb
+++ b/cookbooks/vm/recipes/base.rb
@@ -2,7 +2,7 @@
 include_recipe 'apt'
 
 # commonly needed packages / tools
-%w(vim libcurl3 gconf2 libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb indicator-multiload).each do |pkg|
+%w(vim libcurl4 gconf2 libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb indicator-multiload).each do |pkg|
   package pkg
 end
 

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -18,6 +18,7 @@ end
 dpkg_package 'vagrant' do
   source "#{Chef::Config[:file_cache_path]}/#{vagrant_deb_file}"
   version vagrant_version
+  not_if "which vagrant && vagrant --version | grep -q '#{vagrant_version}'"
 end
 
 # install vagrant plugins

--- a/cookbooks/vm/recipes/vagrant.rb
+++ b/cookbooks/vm/recipes/vagrant.rb
@@ -12,7 +12,6 @@ vagrant_plugins = {
 remote_file "#{Chef::Config[:file_cache_path]}/#{vagrant_deb_file}" do
   source "https://releases.hashicorp.com/vagrant/#{vagrant_version}/#{vagrant_deb_file}"
   checksum vagrant_checksum
-  notifies :install, 'dpkg_package[vagrant]', :immediately
 end
 
 dpkg_package 'vagrant' do


### PR DESCRIPTION
Running the `update-vm.sh` multiple times kept reinstalling Vagrant, Vagrant plugins as well as VirtualBox even though it was already installed.

These were 3 different issues which broke idempotence:

1. the vagrant `dpkg_package` installation was missing a guard expression to check if the desired vagrant version is already installed
2. the `install_vagrant_plugin(name, version)` helper function actually had a guard, but it was no longer working due to a change in the output of `vagrant plugin list` that we parse
3. the VirtualBox installation was not idempotent because we introduced a version conflict by installing libcurl3 at the beginning of the Chef, run where the VirtualBox installation later on needs (and thus reinstalled) libcurl4

This PR fixes the issues above, so that we have proper idempotence restored and subsequent Chef runs no longer reinstall the already installed stuff