### PR TITLE
Disable vagrant-cachier when packaging the VM (fixes broken Software Updater in v0.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,11 @@ or simply for preserving checkpoint releases as a binary images.
 Let's start from a clean state:
 ```
 $ vagrant destroy -f
-$ vagrant up
+```
+
+Make sure vagrant-cachier is disabled when you bring up the VM for packaging:
+```
+$ GLOBAL_VAGRANT_CACHIER_DISABLED=1 vagrant up
 ```
 
 This will provision the VM as usual. Once the provisioning succeeded, we will

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,7 @@ Vagrant::configure("2") do |config|
   EOF
 
   # Ensure we cache as much as possible
-  if Vagrant.has_plugin?("vagrant-cachier")
+  if !ENV["GLOBAL_VAGRANT_CACHIER_DISABLED"] && Vagrant.has_plugin?("vagrant-cachier")
     config.cache.enable :generic, {
       "chef_file_cache" => {cache_dir: "/root/.chef/local-mode-cache/cache"},
       "berkshelf_cache" => {cache_dir: "/home/vagrant/.berkshelf"},


### PR DESCRIPTION
Having fgrehm/vagrant-cachier active when bringing up the VM we intend to export / package later causes some issues with the apt cache (inconsistencies due to the host cache no longer mounted into the VM after packaging, I suspect)

As a result, the "Software Updater" did no longer work in the packaged .ova image for v0.5 and was stuck in "Waiting for another package manager to quit..." state whenever you tried to update.

This PR allows to disable vagrant-cachier when packaging the VM and updates the instructions in the README accordingly.