### PR TITLE
Clarify README regarding regional settings and input languages

### DIFF
--- a/cookbooks/vm/files/default/desktop_readme.md
+++ b/cookbooks/vm/files/default/desktop_readme.md
@@ -7,8 +7,8 @@ A brief guide to walk you through the initial setup of this developer VM
 
 Configure the keyboard layout and adjust the timezone:
 
- * System Settings... -> Text Entry
- * System Settings... -> Time & Date
+ * System Settings -> Region & Language
+ * System Settings -> Details -> Date & Time
 
 If you have a totally different keymap (e.g. on a MacBook) you can always reconfigure it:
 ```

--- a/cookbooks/vm/files/default/desktop_readme.md
+++ b/cookbooks/vm/files/default/desktop_readme.md
@@ -10,7 +10,7 @@ Configure the keyboard layout and adjust the timezone:
  * System Settings -> Region & Language
  * System Settings -> Details -> Date & Time
 
-If you have a totally different keymap (e.g. on a MacBook) you can always reconfigure it:
+In case your input language is missing, or you have a totally different keymap (e.g. on a MacBook) you can always reconfigure it:
 ```
 sudo dpkg-reconfigure keyboard-configuration
 ```


### PR DESCRIPTION
Currently only the "en" language is installed.

If you want to use a german keyboard layout for example, you need to run `sudo dpkg-reconfigure keyboard-configuration`. The README was not clear enough about this