### PR TITLE
Update base packages (add xfreerdp, remove indicator-multiload)

### DIFF
--- a/cookbooks/vm/recipes/base.rb
+++ b/cookbooks/vm/recipes/base.rb
@@ -2,7 +2,7 @@
 include_recipe 'apt'
 
 # commonly needed packages / tools
-%w(vim libcurl4 gconf2 libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb indicator-multiload).each do |pkg|
+%w(vim libcurl4 gconf2 libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb).each do |pkg|
   package pkg
 end
 

--- a/cookbooks/vm/recipes/base.rb
+++ b/cookbooks/vm/recipes/base.rb
@@ -2,7 +2,7 @@
 include_recipe 'apt'
 
 # commonly needed packages / tools
-%w(vim libcurl4 gconf2 libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb freerdp2-x11).each do |pkg|
+%w(vim libcurl4 gconf2 libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb libxtst6 freerdp2-x11).each do |pkg|
   package pkg
 end
 

--- a/cookbooks/vm/recipes/base.rb
+++ b/cookbooks/vm/recipes/base.rb
@@ -2,7 +2,7 @@
 include_recipe 'apt'
 
 # commonly needed packages / tools
-%w(vim libcurl4 gconf2 libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb).each do |pkg|
+%w(vim libcurl4 gconf2 libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev build-essential xvfb freerdp2-x11).each do |pkg|
   package pkg
 end
 

--- a/cookbooks/vm/spec/integration/recipes/base_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/base_spec.rb
@@ -17,7 +17,7 @@ describe 'vm::base' do
 
   it 'installs the xfreerdp client' do
     expect(package('freerdp2-x11')).to be_installed
-    expect(command('xfreerdp --version').exit_status).to eq 0
+    expect(vm_user_gui_command('xfreerdp --version').exit_status).to eq 0
   end
 
   it 'places a README on the Desktop' do

--- a/cookbooks/vm/spec/integration/recipes/base_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/base_spec.rb
@@ -15,8 +15,9 @@ describe 'vm::base' do
     end
   end
 
-  it 'installs the multiload indicator' do
-    expect(package('indicator-multiload')).to be_installed
+  it 'installs the xfreerdp client' do
+    expect(package('freerdp2-x11')).to be_installed
+    expect(command('xfreerdp --version').exit_status).to eq 0
   end
 
   it 'places a README on the Desktop' do


### PR DESCRIPTION
This PR updates the base packages:

 * removed `indicator-multiload` since this is broken on 18.04 GNOME desktop and I haven't found a replacement yet
 * added `freerdp2-x11` (i.e. `xfreerdp` command) so that we can RDP into Windows VMs via `vagrant rdp`