### PR TITLE
Disable vagrant-cachier caching by default, but allow to opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ $ vagrant destroy -f
 
 Make sure vagrant-cachier is disabled when you bring up the VM for packaging:
 ```
-$ GLOBAL_VAGRANT_CACHIER_DISABLED=1 vagrant up
+$ unset GLOBAL_VAGRANT_CACHIER_ENABLED
+$ vagrant up
 ```
 
 This will provision the VM as usual. Once the provisioning succeeded, we will

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,7 @@ Vagrant::configure("2") do |config|
   EOF
 
   # Ensure we cache as much as possible
-  if !ENV["GLOBAL_VAGRANT_CACHIER_DISABLED"] && Vagrant.has_plugin?("vagrant-cachier")
+  if ENV["GLOBAL_VAGRANT_CACHIER_ENABLED"] && Vagrant.has_plugin?("vagrant-cachier")
     config.cache.enable :generic, {
       "chef_file_cache" => {cache_dir: "/root/.chef/local-mode-cache/cache"},
       "berkshelf_cache" => {cache_dir: "/home/vagrant/.berkshelf"},

--- a/cookbooks/vm/templates/default/Vagrantfile.erb
+++ b/cookbooks/vm/templates/default/Vagrantfile.erb
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   end
 
   # enable cachier globally
-  if !ENV["GLOBAL_VAGRANT_CACHIER_DISABLED"] && Vagrant.has_plugin?("vagrant-cachier")
+  if ENV["GLOBAL_VAGRANT_CACHIER_ENABLED"] && Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
 
     # cache bussers, but only if we detect a test-kitchen run


### PR DESCRIPTION
While preparing the exercises I saw quite a few vagrant-cachier related errors surfacing, especially when working with multi-vm Vagrantfiles.

Since this is highly confusing for new users, I disabled the caching that was enabled by default in `~/.vagrant.d/Vagrantfile`.

You now have to explicitly opt-in to having vagrant-cachier caches enabled by default by the `$GLOBAL_VAGRANT_CACHIER_ENABLED` env var to any value, e.g.:
```
$ export GLOBAL_VAGRANT_CACHIER_ENABLED=1
```

To opt-out again, you have to unset the env var:
```
$ unset GLOBAL_VAGRANT_CACHIER_ENABLED
```