### PR TITLE
Fix line endings for Git PS1 (when provisioned from Windows hosts)

### DIFF
--- a/cookbooks/vm/files/default/.gitattributes
+++ b/cookbooks/vm/files/default/.gitattributes
@@ -1,0 +1,1 @@
+git_ps1    eol=lf


### PR DESCRIPTION
Add a `.gitattbributes` file to ensure that git_ps1 is always checked out with proper LF line endings

I believe this fixes #72 at the root, but I need someone who clones / provisions Linus Kitchen from Windows..

@jotbe please review :)
