### PR TITLE
Remove docker in docker related workarounds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
           name: Bring up Developer VM
           command: vagrant up --no-provision
       - run:
+          name: Inject docker systemctl replacement
+          command: vagrant ssh -c 'sudo wget -O /bin/systemctl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py'
+      - run:
           name: Provision Developer VM
           command: UPDATE_VM_FLAGS=--provision-only vagrant provision
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ jobs:
           name: Bring up Developer VM
           command: vagrant up --no-provision
       - run:
-          name: Inject docker systemctl replacement
-          command: vagrant ssh -c 'sudo wget -O /bin/systemctl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py'
-      - run:
           name: Provision Developer VM
           command: UPDATE_VM_FLAGS=--provision-only vagrant provision
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
           name: Bring up Developer VM
           command: vagrant up --no-provision
       - run:
+          name: Inject docker systemctl replacement (required for testing in container only)
+          command: vagrant ssh -c 'sudo wget -O /bin/systemctl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py'
+      - run:
           name: Provision Developer VM
           command: UPDATE_VM_FLAGS=--provision-only vagrant provision
       - run:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,6 +48,10 @@ Vagrant::configure("2") do |config|
     override.vm.box_version = "1.0.0"
     # privileged container is required to run docker-in-docker
     docker.create_args = ["--privileged"]
+    # inject docker systemctl replacement so we can use systemd in the docker container
+    override.vm.provision "shell", privileged: true, inline: <<-EOF
+      sudo wget -O /bin/systemctl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py
+    EOF
   end
 
   # create new login user and pre-provision the deploy key

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,6 +46,8 @@ Vagrant::configure("2") do |config|
   config.vm.provider :docker do |docker, override|
     override.vm.box = "tknerr/baseimage-ubuntu-18.04"
     override.vm.box_version = "1.0.0"
+    # privileged container is required to run docker-in-docker
+    docker.create_args = ["--privileged"]
   end
 
   # create new login user and pre-provision the deploy key

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,10 +48,6 @@ Vagrant::configure("2") do |config|
     override.vm.box_version = "1.0.0"
     # privileged container is required to run docker-in-docker
     docker.create_args = ["--privileged"]
-    # inject docker systemctl replacement so we can use systemd in the docker container
-    override.vm.provision "shell", privileged: true, inline: <<-EOF
-      sudo wget -O /bin/systemctl https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl.py
-    EOF
   end
 
   # create new login user and pre-provision the deploy key

--- a/cookbooks/vm/recipes/docker.rb
+++ b/cookbooks/vm/recipes/docker.rb
@@ -8,19 +8,10 @@ group 'docker' do
   append true
 end
 
-# FIXME: running docker-in-docker-in-docker still fails on circleci, so we skip
-# starting the deamon on circleci for now
-if docker?
-  # only install docker, don't try to start the deamon
-  docker_installation_package 'default' do
-    version docker_version
-    action :create
-  end
-else
-  # install docker and start the docker deamon
-  docker_service 'default' do
-    install_method 'package'
-    version docker_version
-    action [:create, :start]
-  end
+# install docker and start the docker deamon
+docker_service 'default' do
+  install_method 'package'
+  version docker_version
+  action [:create, :start]
 end
+

--- a/cookbooks/vm/recipes/docker.rb
+++ b/cookbooks/vm/recipes/docker.rb
@@ -11,6 +11,7 @@ end
 # install docker and start the docker deamon
 docker_service 'default' do
   install_method 'package'
+  service_manager 'systemd'
   version docker_version
   action [:create, :start]
 end

--- a/cookbooks/vm/recipes/git.rb
+++ b/cookbooks/vm/recipes/git.rb
@@ -1,12 +1,6 @@
 
-if docker?
-  # avoid /dev/fuse issues on circleci
-  extra_options = '--no-install-recommends'
-end
-
 package 'meld' do
   action :install
-  options extra_options || ''
 end
 
 package 'git' do

--- a/cookbooks/vm/recipes/vscode.rb
+++ b/cookbooks/vm/recipes/vscode.rb
@@ -25,11 +25,6 @@ apt_repository 'vscode' do
   key          'https://packages.microsoft.com/keys/microsoft.asc'
 end
 
-# # ensure we have the required gui packages for starting vscode in docker / Circle CI
-# if docker?
-#  package ['libxss-dev', 'gconf2', 'libgtk2.0-0', 'libnotify4', 'gvfs-bin', 'xdg-utils']
-# end
-
 package 'code' do
   version vscode_version
   action :install

--- a/cookbooks/vm/spec/integration/recipes/docker_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/docker_spec.rb
@@ -10,13 +10,7 @@ describe 'vm::docker' do
     expect(vm_user_command('sg docker -c "id"').stdout).to match(/groups=.*\(docker\)/)
   end
 
-  # running docker-in-docker-in-docker still fails on circleci, so we skip it for now
-  # see also:
-  # - https://blog.docker.com/2013/09/docker-can-now-run-within-docker/
-  # - https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/
-  unless in_docker?
-    it 'allows to run docker commands without sudo' do
-      expect(vm_user_command('sg docker -c "docker ps"').stdout).to contain 'CONTAINER ID'
-    end
+  it 'allows to run docker commands without sudo' do
+    expect(vm_user_command('sg docker -c "docker ps"').stdout).to contain 'CONTAINER ID'
   end
 end


### PR DESCRIPTION
Now that we are on CircleCI 2.0 and using "machine" vs "container", we should no longer need these fixes