### PR TITLE
Ensure that the specified docker version is used (fixes the broken build)

### DIFF
--- a/cookbooks/vm/recipes/docker.rb
+++ b/cookbooks/vm/recipes/docker.rb
@@ -17,6 +17,6 @@ docker_installation_package 'default' do
   version docker_version
 end
 docker_service_manager 'default' do
-  action [:create, :start]
+  action :start
 end
 

--- a/cookbooks/vm/recipes/docker.rb
+++ b/cookbooks/vm/recipes/docker.rb
@@ -8,11 +8,15 @@ group 'docker' do
   append true
 end
 
-# install docker and start the docker deamon
-docker_service 'default' do
-  install_method 'package'
-  service_manager 'systemd'
+docker_installation_package 'default' do
+  package_name 'docker-ce-cli'
   version docker_version
+end
+docker_installation_package 'default' do
+  package_name 'docker-ce'
+  version docker_version
+end
+docker_service_manager 'default' do
   action [:create, :start]
 end
 

--- a/cookbooks/vm/recipes/docker.rb
+++ b/cookbooks/vm/recipes/docker.rb
@@ -11,10 +11,16 @@ end
 docker_installation_package 'default' do
   package_name 'docker-ce-cli'
   version docker_version
+  action :create
 end
-docker_service 'default' do	
-  install_method 'package'	
-  version docker_version	
-  action [:create, :start]
+
+docker_installation_package 'default' do
+  package_name 'docker-ce'
+  version docker_version
+  action :create
+end
+
+docker_service_manager 'default' do
+  action :start
 end
 

--- a/cookbooks/vm/recipes/docker.rb
+++ b/cookbooks/vm/recipes/docker.rb
@@ -12,11 +12,9 @@ docker_installation_package 'default' do
   package_name 'docker-ce-cli'
   version docker_version
 end
-docker_installation_package 'default' do
-  package_name 'docker-ce'
-  version docker_version
-end
-docker_service_manager 'default' do
-  action :start
+docker_service 'default' do	
+  install_method 'package'	
+  version docker_version	
+  action [:create, :start]
 end
 

--- a/cookbooks/vm/recipes/docker.rb
+++ b/cookbooks/vm/recipes/docker.rb
@@ -20,7 +20,7 @@ docker_installation_package 'default' do
   action :create
 end
 
-docker_service_manager 'default' do
+docker_service_manager_systemd 'default' do
   action :start
 end
 

--- a/cookbooks/vm/recipes/docker.rb
+++ b/cookbooks/vm/recipes/docker.rb
@@ -8,18 +8,19 @@ group 'docker' do
   append true
 end
 
+# install docker CLI and deamon packages
 docker_installation_package 'default' do
   package_name 'docker-ce-cli'
   version docker_version
   action :create
 end
-
 docker_installation_package 'default' do
   package_name 'docker-ce'
   version docker_version
   action :create
 end
 
+# install docker daemon as a service
 docker_service_manager_systemd 'default' do
   action :start
 end

--- a/cookbooks/vm/spec/integration/recipes/docker_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/docker_spec.rb
@@ -2,8 +2,11 @@ require 'spec_helper'
 
 describe 'vm::docker' do
 
-  it 'installs docker 18.09.5' do
+  it 'installs docker client version 18.09.5' do
     expect(vm_user_command("docker version --format '{{.Client.Version}}'").stdout).to match '18.09.5'
+  end
+
+  it 'installs docker server version 18.09.5' do
     expect(vm_user_command("docker version --format '{{.Server.Version}}'").stdout).to match '18.09.5'
   end
 

--- a/cookbooks/vm/spec/integration/recipes/docker_spec.rb
+++ b/cookbooks/vm/spec/integration/recipes/docker_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'vm::docker' do
 
   it 'installs docker 18.09.5' do
-    expect(vm_user_command('docker -v').stdout).to match 'Docker version 18.09.5'
+    expect(vm_user_command("docker version --format '{{.Client.Version}}'").stdout).to match '18.09.5'
+    expect(vm_user_command("docker version --format '{{.Server.Version}}'").stdout).to match '18.09.5'
   end
 
   it 'adds the vm user to the docker group' do


### PR DESCRIPTION
Even though we specified docker version "18.09.5" it installs "18.09.6" and the build is currently failing due to that.

The issue was that `docker_service` only installs "docker-ce" package at version "18.09.5", which has an unpinned dependency to latest version of "docker-ce-cli"

This PR corrects it by explicitly specifying both at the desired version and also adds separate test for docker client and service version