### PR TITLE
Add support for vmware desktop provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ $ VBoxManage export "Linus Kitchen v0.1.0" --output "linus-kitchen-v0.1.0_virtua
 For VMware:
 ```
 $ vagrant halt
-$ VMX_FILE=`cat .vagrant/machines/default/vmware_fusion/id`
+$ VMX_FILE=`cat .vagrant/machines/default/vmware_desktop/id`
 $ ovftool --name="Linus Kitchen v0.1.0" "$VMX_FILE" linus-kitchen-v0.1.0_vmware.ova
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant::configure("2") do |config|
   end
 
   # vmware specific customizations
-  [:vmware_workstation, :vmware_fusion].each do |vmware_provider|
+  [:vmware_workstation, :vmware_fusion, :vmware_desktop].each do |vmware_provider|
     config.vm.provider vmware_provider do |vmware, override|
       vmware.vmx["displayname"] = "Linus Kitchen"
       vmware.vmx["numvcpus"] = "#{Etc.nprocessors}"


### PR DESCRIPTION
Add support for "vmware_desktop" (which covers both fusion and workstation) and make it the default in the README when packaging new boxes